### PR TITLE
sync-spine: canvas → code proposal for polaris.avatar

### DIFF
--- a/examples/polaris/contracts/avatar.contract.json
+++ b/examples/polaris/contracts/avatar.contract.json
@@ -2,21 +2,20 @@
   "$schema": "../../../contracts/contract.schema.json",
   "id": "polaris.avatar",
   "name": "Avatar",
-  "version": "0.4.0",
+  "version": "0.1.0",
   "status": "draft",
-  "description": "PROPOSED contract extracted from examples/polaris/.polaris-clone/polaris-react/src/components/Avatar/Avatar.tsx (react-tsx + css-module adapters) — API surface AND anatomy (structure, token bindings, layout, states) read from source; design bindings await reconciliation and human review. PROMOTED showcase contract: API surface extracted mechanically from Shopify/polaris @ 2b1ea88625e0613853ca8577c9acd1980a90f382 (polaris-react 13.10.1, MIT © Shopify, extracted 2026-07-18); styling bindings promoted from the component's own module.css under the reviewed class map in examples/polaris/scripts/curation.ts — every carried binding and every named refusal is listed in examples/polaris/extraction/PROMOTION.md. COMPUTED-ENRICHED (extract/computed): unlabeled styled channels minted from computed-style capture of @shopify/polaris@13.9.5 in headless Chromium 151.0.7922.34; overflow channels in the sibling extension file. FLOOR-PROMOTED (examples/polaris/scripts/promote-floor.ts): resolved.contract.json — computed-capture truth; minted leaves source-aliased to Polaris's own CSS-variable references where verified (source-bindings.json); extension sidecar carries the named overflow.",
+  "description": "PROPOSED contract extracted from the design canvas (extract/figma dump v1) — API, anatomy, and token bindings inverted from the drawn structure. Semantics beyond the name/axis inference table, a11y, events, and slot accepts are not canvas-recoverable; review before adoption.",
   "semantics": {
-    "element": "span"
+    "element": "div"
   },
   "props": [
     {
       "name": "size",
-      "description": "Size of avatar",
       "type": {
         "enum": [
+          "md",
           "xs",
           "sm",
-          "md",
           "lg",
           "xl"
         ]
@@ -27,9 +26,9 @@
           "kind": "VARIANT",
           "property": "Size",
           "values": {
+            "md": "Md",
             "xs": "Xs",
             "sm": "Sm",
-            "md": "Md",
             "lg": "Lg",
             "xl": "Xl"
           }
@@ -40,22 +39,7 @@
       }
     },
     {
-      "name": "name",
-      "description": "The name of the person",
-      "type": "text",
-      "bindings": {
-        "figma": {
-          "kind": "TEXT",
-          "property": "Name"
-        },
-        "code": {
-          "prop": "name"
-        }
-      }
-    },
-    {
       "name": "initials",
-      "description": "Initials of person to display. Default TP matches developed receipt (examples/polaris/receipts/avatar/default.png); without a string default, contentFallsThrough kept only the silhouette SVG children.",
       "type": "text",
       "default": "TP",
       "bindings": {
@@ -67,273 +51,54 @@
           "prop": "initials"
         }
       }
-    },
-    {
-      "name": "customer",
-      "description": "Whether the avatar is for a customer",
-      "type": "boolean",
-      "bindings": {
-        "figma": {
-          "kind": "BOOLEAN",
-          "property": "Customer"
-        },
-        "code": {
-          "prop": "customer"
-        }
-      }
-    },
-    {
-      "name": "source",
-      "description": "URL of the avatar image which falls back to initials if the image fails to load",
-      "type": "text",
-      "bindings": {
-        "figma": {
-          "kind": "TEXT",
-          "property": "Source"
-        },
-        "code": {
-          "prop": "source"
-        }
-      }
-    },
-    {
-      "name": "accessibilityLabel",
-      "description": "Accessible label for the avatar image",
-      "type": "text",
-      "bindings": {
-        "figma": {
-          "kind": "TEXT",
-          "property": "Accessibility Label"
-        },
-        "code": {
-          "prop": "accessibilityLabel"
-        }
-      }
-    },
-    {
-      "name": "withInitials",
-      "description": "Structure-creating optional prop promoted by the computed floor (round 4): ON mounts the library's `initials` (\"TP\"); the created subtree is carried as parts gated on this prop. Default true so canvas showcase matches developed initials receipt (silhouette remains via Show WithInitials=false + icon assets once gated).",
-      "type": "boolean",
-      "default": true,
-      "bindings": {
-        "figma": {
-          "kind": "BOOLEAN",
-          "property": "Show WithInitials"
-        },
-        "code": {
-          "prop": "withInitials"
-        }
-      }
     }
   ],
   "states": [],
   "anatomy": {
     "root": {
-      "tokens": {
-        "background": "{p.color-avatar-one-bg-fill}",
-        "color": "{p.color-avatar-one-text-on-bg-fill}",
-        "bottom": "{imported.shared.size-0}",
-        "left": "{imported.shared.size-0}",
-        "right": "{imported.shared.size-0}",
-        "top": "{imported.shared.size-0}"
-      },
-      "literals": {
-        "min-width": "20px"
-      },
-      "literalsByProp": [
-        {
-          "prop": "size",
-          "map": {
-            "xs": {
-              "width": "20px"
-            },
-            "sm": {
-              "width": "24px"
-            },
-            "md": {
-              "width": "28px"
-            },
-            "lg": {
-              "width": "32px"
-            },
-            "xl": {
-              "width": "40px"
-            }
-          }
-        }
-      ],
-      "declared": {
-        "display": "block",
-        "max-width": "100%",
-        "overflow-x": "hidden",
-        "overflow-y": "hidden",
-        "position": "relative",
-        "user-select": "none"
+      "layout": {
+        "display": "flex",
+        "direction": "column"
       },
       "parts": {
         "initials": {
-          "element": "span",
-          "tokens": {
-            "font-size": "{p.font-size-325}",
-            "font-weight": "{p.font-weight-regular}",
-            "bottom": "{imported.shared.size-0}",
-            "left": "{imported.shared.size-0}",
-            "min-height": "{imported.shared.size-0}",
-            "min-width": "{imported.shared.size-0}",
-            "right": "{imported.shared.size-0}",
-            "top": "{imported.shared.size-0}"
-          },
-          "content": {
-            "prop": "initials"
-          },
-          "declared": {
-            "position": "absolute",
-            "aspect-ratio": "1 / 1",
-            "user-select": "none"
-          },
           "layout": {
-            "display": "flex",
-            "align": "center",
-            "justify": "center"
+            "direction": "row",
+            "justify": "center",
+            "align": "center"
           },
           "parts": {
-            "initials-xs": {
-              "icon": {
-                "asset": "avatar-initials-xs",
-                "size": 20
+            "TP": {
+              "content": {
+                "prop": "initials"
               },
-              "visibleWhen": {
-                "prop": "size",
-                "equals": "xs"
-              },
-              "description": "Per-value svg content promoted from the computed floor: the glyph drawn when size=xs."
-            },
-            "initials-sm": {
-              "icon": {
-                "asset": "avatar-initials-sm",
-                "size": 24
-              },
-              "visibleWhen": {
-                "prop": "size",
-                "equals": "sm"
-              },
-              "description": "Per-value svg content promoted from the computed floor: the glyph drawn when size=sm."
-            },
-            "initials-md": {
-              "icon": {
-                "asset": "avatar-initials-md",
-                "size": 28
-              },
-              "visibleWhen": {
-                "prop": "size",
-                "equals": "md"
-              },
-              "description": "Per-value svg content promoted from the computed floor: the glyph drawn when size=md."
-            },
-            "initials-lg": {
-              "icon": {
-                "asset": "avatar-initials-lg",
-                "size": 32
-              },
-              "visibleWhen": {
-                "prop": "size",
-                "equals": "lg"
-              },
-              "description": "Per-value svg content promoted from the computed floor: the glyph drawn when size=lg."
-            },
-            "initials-xl": {
-              "icon": {
-                "asset": "avatar-initials-xl",
-                "size": 40
-              },
-              "visibleWhen": {
-                "prop": "size",
-                "equals": "xl"
-              },
-              "description": "Per-value svg content promoted from the computed floor: the glyph drawn when size=xl."
-            }
-          },
-          "tokensByProp": [
-            {
-              "prop": "size",
-              "map": {
-                "lg": {
-                  "height": "{imported.avatar.initials.height.lg}",
-                  "width": "{imported.avatar.initials.width.lg}"
-                },
-                "md": {
-                  "height": "{imported.avatar.initials.height.md}",
-                  "width": "{imported.avatar.initials.width.md}"
-                },
-                "sm": {
-                  "height": "{imported.avatar.initials.height.sm}",
-                  "width": "{imported.avatar.initials.width.sm}"
-                },
-                "xl": {
-                  "height": "{imported.avatar.initials.height.xl}",
-                  "width": "{imported.avatar.initials.width.xl}"
-                },
-                "xs": {
-                  "height": "{imported.avatar.initials.height.xs}",
-                  "width": "{imported.avatar.initials.width.xs}"
-                }
+              "tokens": {
+                "color": "{imported.avatar-polaris-avatar.initials-tp.color}",
+                "font-size": "{imported.avatar-polaris-avatar.initials-tp.font-size}",
+                "font-weight": "{imported.avatar-polaris-avatar.initials-tp.font-weight}"
               }
-            }
-          ]
-        }
-      },
-      "tokensByProp": [
-        {
-          "prop": "size",
-          "map": {
-            "lg": {
-              "border-bottom-left-radius": "{imported.avatar.root.border-bottom-left-radius.lg}",
-              "border-bottom-right-radius": "{imported.avatar.root.border-bottom-right-radius.lg}",
-              "border-top-left-radius": "{imported.avatar.root.border-top-left-radius.lg}",
-              "border-top-right-radius": "{imported.avatar.root.border-top-right-radius.lg}",
-              "height": "{imported.avatar.root.height.lg}"
-            },
-            "md": {
-              "border-bottom-left-radius": "{imported.avatar.root.border-bottom-left-radius.md}",
-              "border-bottom-right-radius": "{imported.avatar.root.border-bottom-right-radius.md}",
-              "border-top-left-radius": "{imported.avatar.root.border-top-left-radius.md}",
-              "border-top-right-radius": "{imported.avatar.root.border-top-right-radius.md}",
-              "height": "{imported.avatar.root.height.md}"
-            },
-            "sm": {
-              "border-bottom-left-radius": "{imported.avatar.root.border-bottom-left-radius.sm}",
-              "border-bottom-right-radius": "{imported.avatar.root.border-bottom-right-radius.sm}",
-              "border-top-left-radius": "{imported.avatar.root.border-top-left-radius.sm}",
-              "border-top-right-radius": "{imported.avatar.root.border-top-right-radius.sm}",
-              "height": "{imported.avatar.root.height.sm}"
-            },
-            "xl": {
-              "border-bottom-left-radius": "{imported.avatar.root.border-bottom-left-radius.xl}",
-              "border-bottom-right-radius": "{imported.avatar.root.border-bottom-right-radius.xl}",
-              "border-top-left-radius": "{imported.avatar.root.border-top-left-radius.xl}",
-              "border-top-right-radius": "{imported.avatar.root.border-top-right-radius.xl}",
-              "height": "{imported.avatar.root.height.xl}"
-            },
-            "xs": {
-              "border-bottom-left-radius": "{imported.avatar.root.border-bottom-left-radius.xs}",
-              "border-bottom-right-radius": "{imported.avatar.root.border-bottom-right-radius.xs}",
-              "border-top-left-radius": "{imported.avatar.root.border-top-left-radius.xs}",
-              "border-top-right-radius": "{imported.avatar.root.border-top-right-radius.xs}",
-              "height": "{imported.avatar.root.height.xs}"
             }
           }
         }
-      ]
+      },
+      "tokens": {
+        "background-color": "{imported.avatar-polaris-avatar.root.background-color}",
+        "border-radius": "{imported.avatar-polaris-avatar.root.border-radius.{size}}",
+        "min-width": "{imported.avatar-polaris-avatar.root.min-width}",
+        "width": "{imported.avatar-polaris-avatar.root.width.{size}}",
+        "height": "{imported.avatar-polaris-avatar.root.height.{size}}"
+      }
     }
   },
   "anchors": {
     "figma": {
-      "fileKey": null,
-      "componentSetKey": null
+      "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
+      "componentSetKey": "e5f076f114cabc55a4b482e4b7326d7895c1aade",
+      "nodeId": "1:7849"
     },
     "code": {
-      "importPath": "polaris-react/src/components/Avatar/Avatar",
-      "export": "Avatar"
+      "importPath": "src/components/AvatarPolarisAvatar",
+      "export": "AvatarPolarisAvatar"
     }
   }
 }

--- a/examples/polaris/contracts/polaris-avatar.sync-minted.dtcg.json
+++ b/examples/polaris/contracts/polaris-avatar.sync-minted.dtcg.json
@@ -1,0 +1,96 @@
+{
+  "imported": {
+    "avatar-polaris-avatar": {
+      "root": {
+        "background-color": {
+          "$value": "#c530c5",
+          "$type": "color"
+        },
+        "border-radius": {
+          "md": {
+            "$value": "6px",
+            "$type": "dimension"
+          },
+          "xs": {
+            "$value": "4px",
+            "$type": "dimension"
+          },
+          "sm": {
+            "$value": "6px",
+            "$type": "dimension"
+          },
+          "lg": {
+            "$value": "8px",
+            "$type": "dimension"
+          },
+          "xl": {
+            "$value": "8px",
+            "$type": "dimension"
+          }
+        },
+        "min-width": {
+          "$value": "20px",
+          "$type": "dimension"
+        },
+        "width": {
+          "md": {
+            "$value": "28px",
+            "$type": "dimension"
+          },
+          "xs": {
+            "$value": "20px",
+            "$type": "dimension"
+          },
+          "sm": {
+            "$value": "24px",
+            "$type": "dimension"
+          },
+          "lg": {
+            "$value": "32px",
+            "$type": "dimension"
+          },
+          "xl": {
+            "$value": "40px",
+            "$type": "dimension"
+          }
+        },
+        "height": {
+          "md": {
+            "$value": "28px",
+            "$type": "dimension"
+          },
+          "xs": {
+            "$value": "20px",
+            "$type": "dimension"
+          },
+          "sm": {
+            "$value": "24px",
+            "$type": "dimension"
+          },
+          "lg": {
+            "$value": "32px",
+            "$type": "dimension"
+          },
+          "xl": {
+            "$value": "40px",
+            "$type": "dimension"
+          }
+        }
+      },
+      "initials-tp": {
+        "color": {
+          "$value": "#fdeffd",
+          "$type": "color"
+        },
+        "font-size": {
+          "$value": "13px",
+          "$type": "dimension"
+        },
+        "font-weight": {
+          "$value": "500",
+          "$type": "number"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- ds-contracts sync-spine: key=polaris.avatar@GnQnjSNBXtgtd2Ht0Hs1C8 ledger-stamp=v6:635946300 ledger-baseline=none observed-stamp=v6:2102008762 observed-dump=dumpv1:4090578915 file-version=2385311290720626690 -->

# Canvas → code: proposed contract for `polaris.avatar`

The sync spine observed **canvas-ahead** drift for `polaris.avatar` (Figma file `GnQnjSNBXtgtd2Ht0Hs1C8`, set `1:7849`).

## Drift (sync observe)

| fact | value |
|---|---|
| status | canvas-ahead |
| canvas evidence | stamp |
| ledger stamp at last sync | `v6:635946300` |
| ledger observation baseline | `none` |
| observed stamp now | `v6:2102008762` |
| observed dump fingerprint now | `dumpv1:4090578915` |
| note | canvas stamp v6:2102008762 ≠ ledger v6:635946300 — the set was re-stamped by a write this ledger did not record |

## Per-property classification (proposal vs current contract)

5 matched · 2 canvas-absent (declared fidelity limits) · 34 mismatch

| status | subject | detail |
|---|---|---|
| matched | id |  |
| matched | name |  |
| canvas-absent | semantics | element/role are not drawn on the canvas ({"element":"span"}) |
| mismatch | prop size type | {"enum":["xs","sm","md","lg","xl"]} vs {"enum":["md","xs","sm","lg","xl"]} |
| mismatch | prop size bindings.figma.values | {"xs":"Xs","sm":"Sm","md":"Md","lg":"Lg","xl":"Xl"} vs {"md":"Md","xs":"Xs","sm":"Sm","lg":"Lg","xl":"Xl"} |
| mismatch | prop name | missing from proposal |
| matched | prop initials |  |
| mismatch | prop customer | missing from proposal |
| mismatch | prop source | missing from proposal |
| mismatch | prop accessibilityLabel | missing from proposal |
| mismatch | prop withInitials | missing from proposal |
| mismatch | part root/initials/initials-xs | missing from proposal |
| mismatch | part root/initials/initials-sm | missing from proposal |
| mismatch | part root/initials/initials-md | missing from proposal |
| mismatch | part root/initials/initials-lg | missing from proposal |
| mismatch | part root/initials/initials-xl | missing from proposal |
| mismatch | part root/initials/TP | proposal has a part the contract does not |
| matched | part root child order |  |
| mismatch | part root layout | {"mode":"HORIZONTAL","primary":"CENTER","counter":"CENTER","grow":false,"stretch":false} vs {"mode":"VERTICAL","primary":"MIN","counter":"MIN","grow":false,"stretch":false} |
| mismatch | part root background | {p.color-avatar-one-bg-fill} missing from proposal |
| mismatch | part root bottom | {imported.shared.size-0} missing from proposal |
| mismatch | part root left | {imported.shared.size-0} missing from proposal |
| mismatch | part root right | {imported.shared.size-0} missing from proposal |
| mismatch | part root top | {imported.shared.size-0} missing from proposal |
| mismatch | part root background-color | proposal has {imported.avatar-polaris-avatar.root.background-color}, contract has nothing |
| mismatch | part root border-radius | proposal has {imported.avatar-polaris-avatar.root.border-radius.{size}}, contract has nothing |
| mismatch | part root min-width | proposal has {imported.avatar-polaris-avatar.root.min-width}, contract has nothing |
| mismatch | part root width | proposal has {imported.avatar-polaris-avatar.root.width.{size}}, contract has nothing |
| mismatch | part root height | proposal has {imported.avatar-polaris-avatar.root.height.{size}}, contract has nothing |
| matched | part root/initials layout |  |
| mismatch | part root/initials bottom | {imported.shared.size-0} missing from proposal |
| mismatch | part root/initials left | {imported.shared.size-0} missing from proposal |
| mismatch | part root/initials min-height | {imported.shared.size-0} missing from proposal |
| mismatch | part root/initials min-width | {imported.shared.size-0} missing from proposal |
| mismatch | part root/initials right | {imported.shared.size-0} missing from proposal |
| mismatch | part root/initials top | {imported.shared.size-0} missing from proposal |
| mismatch | part root/initials content | {"prop":"initials"} vs undefined |
| canvas-absent | part root/initials element | host element ("span") is not drawn on the canvas |
| mismatch | text root/initials color (effective) | {p.color-avatar-one-text-on-bg-fill} missing from proposal |
| mismatch | text root/initials font-size (effective) | {p.font-size-325} missing from proposal |
| mismatch | text root/initials font-weight (effective) | {p.font-weight-regular} missing from proposal |

## Honesty — this is an inversion, not a round trip

This proposed contract is a **reviewable inversion** of what the headless REST surface could read off the canvas (`projectionMode: reviewable-inversion`; unbound canvas values are minted as provisional `imported.*` tokens rather than guessed into semantic names). It is NOT a proven round trip of the shipping contract: a mismatch row can be a designer edit **or** a read limit of the import route (variables degradation, REST captureGaps — named in the proposal notes). Review every row; nothing in this PR was invented.

## Proposal notes

- this dump's reader could not see: multi-mode variable values (dump v1.6 modes): not captured on this route — only one mode’s resolved values are readable, so a theme/mode axis resolves single-mode and the other modes’ values are absent; absolute placement on non-shape nodes (dump v1.7): not captured on this route — an out-of-flow FRAME/TEXT (e.g. a corner-pinned badge) re-enters the flow and renders in-line; image fills (dump v1.7 imageFill / v1.9 imageHash): not captured on this route — an IMAGE paint (e.g. an avatar photo) is read as no fill and renders as an empty box; fixed sizes on plain rectangles (dump v1.8 fixedSize): not captured on this route — a drawn width/height is lost and the node sizes to content; instance text overrides (dump v1.10 textOverrides): not captured on this route — a host’s edited label is read as the child’s own default characters; strokeAlign (dump v1.11): not captured on this route — an OUTSIDE stroke (focus ring) will be read as an inward border; layout wrap + row spacing (dump v1.12 layout.wrap/rowSpacing): not captured on this route — a wrapping row is read as a single non-wrapping line; the full constraints map (dump v1.13): not captured on this route — MIN/MAX/CENTER/STRETCH/SCALE pinning carries only on shape decor, not on other node types — absence of these facts is a READ limit of the import route, not evidence about the design; re-import via the plugin dump (extract/figma/dump.plugin.js, dump v1.13) to capture them
- semantics.element defaulted to "div" — element/role/ARIA are not drawn on the canvas and the name/axis inference table matched nothing; set the real host element
- Avatar (polaris.avatar):root/initials/TP: typography (13px Medium) matches 0 derived text styles — font tokens not proposed, review
- Avatar (polaris.avatar):root: root width is DRAWN FIXED in every variant — the observed dimension (28/20/24/32/40px, dump v1.5 bbox) is proposed as a minted root token (the drawn value is the only witness; rename against your real tokens)
- Avatar (polaris.avatar):root: root height is DRAWN FIXED in every variant — the observed dimension (28/20/24/32/40px, dump v1.5 bbox) is proposed as a minted root token (the drawn value is the only witness; rename against your real tokens)
- prop `initials`: the single text prop carries the component's main content — repo contracts bind main content to code prop "children" (ds.button convention); adopt by setting bindings.code.prop to "children" when this is the label (note-only, nothing renamed mechanically)
- contract name: drawn set name "Avatar (polaris.avatar)" is not a PascalCase component name — proposed as "AvatarPolarisAvatar" (the canvas set keeps its own name; the componentSetKey/nodeId anchors carry identity)
- contract id: drawn set name "Avatar (polaris.avatar)" contains characters a contract id cannot carry — id proposed as "polaris.avatar-polaris-avatar" (rule: lowercase kebab, illegal characters → hyphens, runs collapsed, edge hyphens stripped, digit-led/empty gets "c"); the canvas set keeps its own name and the componentSetKey/nodeId anchors carry identity
- Avatar (polaris.avatar):root cornerRadius: observed 6 carried as a PROVISIONAL minted token (rename against your real system) — nearest real tokens by value: {p.height-2400}, {p.space-2400}, {p.width-2400}; the proposal binds the provisional name, never a real token the canvas did not use
- Avatar (polaris.avatar):root/initials/TP fontWeight: observed 500 carried as a PROVISIONAL minted token (rename against your real system) — nearest real tokens by value: {p.motion-duration-500}; the proposal binds the provisional name, never a real token the canvas did not use
- MINTED {imported.avatar-polaris-avatar.root.background-color} = #c530c5 — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root background-color
- MINTED {imported.avatar-polaris-avatar.root.border-radius.md} = 6px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root border-radius (size=md)
- MINTED {imported.avatar-polaris-avatar.root.border-radius.xs} = 4px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root border-radius (size=xs)
- MINTED {imported.avatar-polaris-avatar.root.border-radius.sm} = 6px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root border-radius (size=sm)
- MINTED {imported.avatar-polaris-avatar.root.border-radius.lg} = 8px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root border-radius (size=lg)
- MINTED {imported.avatar-polaris-avatar.root.border-radius.xl} = 8px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root border-radius (size=xl)
- MINTED {imported.avatar-polaris-avatar.root.min-width} = 20px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root min-width
- MINTED {imported.avatar-polaris-avatar.initials-tp.color} = #fdeffd — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root/initials/TP color
- MINTED {imported.avatar-polaris-avatar.initials-tp.font-size} = 13px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root/initials/TP font-size
- MINTED {imported.avatar-polaris-avatar.initials-tp.font-weight} = 500 — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root/initials/TP font-weight
- MINTED {imported.avatar-polaris-avatar.root.width.md} = 28px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root width (size=md)
- MINTED {imported.avatar-polaris-avatar.root.width.xs} = 20px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root width (size=xs)
- MINTED {imported.avatar-polaris-avatar.root.width.sm} = 24px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root width (size=sm)
- MINTED {imported.avatar-polaris-avatar.root.width.lg} = 32px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root width (size=lg)
- MINTED {imported.avatar-polaris-avatar.root.width.xl} = 40px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root width (size=xl)
- MINTED {imported.avatar-polaris-avatar.root.height.md} = 28px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root height (size=md)
- MINTED {imported.avatar-polaris-avatar.root.height.xs} = 20px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root height (size=xs)
- MINTED {imported.avatar-polaris-avatar.root.height.sm} = 24px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root height (size=sm)
- MINTED {imported.avatar-polaris-avatar.root.height.lg} = 32px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root height (size=lg)
- MINTED {imported.avatar-polaris-avatar.root.height.xl} = 40px — machine-named from a resolved value — rename against your real tokens (provisional); bound at: Avatar (polaris.avatar):root height (size=xl)
- proposal identity pinned to the ledger record: id "polaris.avatar-polaris-avatar" (derived from canvas set name "Avatar (polaris.avatar)") → polaris.avatar; minted token paths keep the derived stem
- token corpus: examples/polaris/tokens/polaris-light.dtcg.json (examples/polaris/extract.config.json)
- unbound values: 0; minted tokens: 20

## Files in this PR

- `examples/polaris/contracts/avatar.contract.json` (contract)
- `examples/polaris/contracts/polaris-avatar.sync-minted.dtcg.json` (tokens)

## After merging

1. Re-baseline the sync ledger so the next observation records the adoption: `npm run sync:observe -- --update` (or `ds-contracts figma receive --apply` when landing via the envelope path).
2. Regenerate code surfaces from the adopted contract (`ds-contracts generate …`).

_Opened by the sync spine (sync/spine.ts). The fingerprint marker at the top is how the spine avoids opening a duplicate PR for this same drift._
