### PR TITLE
Phase 2 exam — canvas → code on a hand-built kit: 295 silent facts, 19 cases authored

### DIFF
--- a/accuracy/grammar.json
+++ b/accuracy/grammar.json
@@ -45,10 +45,10 @@
     {
       "id": "canvas",
       "path": "extract/figma/conformance/MANIFEST.json",
-      "count": 116,
+      "count": 135,
       "expectations": {
-        "CARRIED": 93,
-        "LEDGERED": 14,
+        "CARRIED": 100,
+        "LEDGERED": 26,
         "REFUSED": 9
       }
     },

--- a/docs/24-what-works.md
+++ b/docs/24-what-works.md
@@ -383,10 +383,10 @@ filter that decides carriage scores 100% on a channel it never opened.
 
 | manifest | cases | breakdown | source |
 |---|---|---|---|
-| canvas constructs | 116 | CARRIED 93 · LEDGERED 14 · REFUSED 9 | `extract/figma/conformance/MANIFEST.json` |
+| canvas constructs | 135 | CARRIED 100 · LEDGERED 26 · REFUSED 9 | `extract/figma/conformance/MANIFEST.json` |
 | CSS / DOM frontier | 82 | CARRIED 42 · REFUSED 18 · UNSUPPORTED 18 · LOWERED 4 | `conformance/MANIFEST.json` |
 
-Of the 116 canvas constructs, **116** are `green`.
+Of the 135 canvas constructs, **116** are `green`, **19** are `red`.
 A construct that is neither carried nor named-refused is a hard failure of that
 suite — "it silently did nothing" is not an allowed outcome.
 
@@ -540,7 +540,7 @@ npm run capability:fresh
 | `examples/untitled-ui/renders/fidelity.json` | `0a468d6682bf` | 84,415 | Untitled UI scored fidelity table |
 | `extract/computed/out/**/numbers.json` | `d5bcd57769dc` | 1,056,246 | capture counts + determinism receipts — 184 files |
 | `extract/computed/out/**/scorecard.json` | `3f0067a3f412` | 16,283,364 | computed-equality per component — 184 files |
-| `extract/figma/conformance/MANIFEST.json` | `71392fbbb21e` | 67,755 | canvas construct vocabulary |
+| `extract/figma/conformance/MANIFEST.json` | `9c2374097aba` | 86,207 | canvas construct vocabulary |
 | `extract/figma/dagger-census.json` | `02c91c8d4a42` | 6,112 | dropped-fact receipt census |
 | `extract/figma/roundtrip-uui/report.json` | `3f4d66b6b63c` | 7,704,705 | canvas→code→canvas round trip |
 

--- a/examples/untitled-ui/LEDGER.md
+++ b/examples/untitled-ui/LEDGER.md
@@ -15,9 +15,9 @@ Fifteen Untitled UI component sets were drawn by hand on a Figma canvas, capture
 | instrument | what it holds the tool to | current reading | artifact |
 |---|---|---|---|
 | Pixel fidelity | a render of the emitted React vs the canvas reference, per variant | **92.7%** mean over 537 scored variants in 15 sets (best toggle-base 98.0%, worst tooltip 81.2%) | `renders/fidelity.json` |
-| Document-model conformance | one hand-authored case per Figma construct, with a hand-authored expected disposition | **116/116** green, 0 pinned red — 93 constructs expected CARRIED, 9 REFUSED, 14 LEDGERED | `extract/figma/conformance/MANIFEST.json` |
+| Document-model conformance | one hand-authored case per Figma construct, with a hand-authored expected disposition | **116/135** green, 19 pinned red — 100 constructs expected CARRIED, 9 REFUSED, 26 LEDGERED | `extract/figma/conformance/MANIFEST.json` |
 | Canvas→code→canvas round trip | every (variant ▸ node ▸ channel) fact, four ways | **15/15** executed to fact diff · **0/15 verified exact** · 11,400 matched · 1,857 diverged · 7,671 loss · 15,359 invented | `extract/figma/roundtrip-uui/report.json` |
-| The named-refusal surface | what the pipeline writes down when it will not carry something | **491** capture receipts in 8 codes · 15 stub contracts · 23 named conformance limits · 1 refused icon export | dumps, contracts, icon manifest |
+| The named-refusal surface | what the pipeline writes down when it will not carry something | **491** capture receipts in 8 codes · 15 stub contracts · 35 named conformance limits · 1 refused icon export | dumps, contracts, icon manifest |
 
 ### The one sentence
 
@@ -43,7 +43,7 @@ Method, quoted from `renders/FIDELITY.md`: *Score = % of pixels REPRODUCED, meas
 
 ## 2. What carries
 
-The document-model fixture is the answer to "will it survive the boundary at all". It is 116 hand-authored cases whose expected disposition was written from the Figma documentation model, never from engine output; a construct that is neither carried nor named-refused is a hard failure. **93 constructs are proven CARRIED and green.** Grouped, with the case ids you can re-run:
+The document-model fixture is the answer to "will it survive the boundary at all". It is 135 hand-authored cases whose expected disposition was written from the Figma documentation model, never from engine output; a construct that is neither carried nor named-refused is a hard failure. **93 constructs are proven CARRIED and green.** Grouped, with the case ids you can re-run:
 
 | construct family | carried | case ids |
 |---|---|---|
@@ -122,7 +122,7 @@ The 15 non-stub contracts carry their own standing refusal, which an adopter sho
 
 ### 3.3 Named refusals in the document model
 
-9 constructs are refused **by name** — the proposal must produce a note, never a guess. 14 more are LEDGERED: carried as a receipt while the contract stays honest and invents nothing. All 23 are green, meaning the refusal itself is what the fixture verifies. Side is derived from the manifest's own wording (a case whose text says "capture-boundary" or "the capture receipts …" is capture-side; everything else is inversion-side).
+9 constructs are refused **by name** — the proposal must produce a note, never a guess. 26 more are LEDGERED: carried as a receipt while the contract stays honest and invents nothing. All 35 are green, meaning the refusal itself is what the fixture verifies. Side is derived from the manifest's own wording (a case whose text says "capture-boundary" or "the capture receipts …" is capture-side; everything else is inversion-side).
 
 | case | disposition | side | the construct | why it is refused |
 |---|---|---|---|---|
@@ -134,8 +134,20 @@ The 15 non-stub contracts carry their own standing refusal, which an adopter sho
 | `grid-named-area-slots` | LEDGERED | inversion-side | three children occupying what a contract would have declared as three NAMED areas, drawn as ordinary frames | G4: Figma has no native area names — the canvas carries only the rect. The geometry is CARRIED exactly as per-child placement, and the NAME loss must be NAMED rather than silent; an area name survives only through a part that already has a name on the canvas (a SLOT node — see grid-area-slot-native) |
 | `instance-override-paint-observed` | LEDGERED | inversion-side | an observed subtree paint on an instance LINKED to a real contract (classic path, no instanceOverrides ledger) | the child contract owns its paint; a per-usage override is not representable on a component ref without the opt-in override machinery - ledgered by name |
 | `radius-per-corner` | LEDGERED | capture-side | per-corner (non-uniform) radii (capture-boundary: dump v1 carries a uniform radius only) | the capture receipts radii-nonuniform; nothing corner-shaped may be invented |
+| `rest-effect-bound-variables` | LEDGERED | inversion-side | REST: a DROP_SHADOW whose radius/spread/color/offset are bound to variables, with no variables response | every other bound channel degrades to its literal under a named variable-unresolved receipt; an effect binding must get the same receipt — BOUND_FIELDS_SKIPPED silences "effects" and the effect mapper reads no boundVariables |
+| `rest-effect-style-identity` | LEDGERED | inversion-side | REST: a DROP_SHADOW on the root that rides an EFFECT style (node.styles.effect + styles metadata name "shadow/md") | the shadow geometry carries as box-shadow; the STYLE identity is a token-class fact (the same way text.style carries a TextStyle name) and must be carried or named — map.ts reads styles.text only |
+| `rest-instance-fill-override` | LEDGERED | inversion-side | REST: a nested INSTANCE whose internal vector fill is OVERRIDDEN by the host (overrides[].overriddenFields includes "fills") | instance internals are elided by rule, but a HOST override is a host fact (the icon colour per variant) and must be named |
+| `rest-instance-slot-prop-value` | LEDGERED | inversion-side | REST: a nested INSTANCE with a SLOT-typed property value ({guid}) in componentProperties | an object is not a prop value the contract grammar can hold (exact mode crashed on Card Grid with a ContractSchema error); it must be dropped BY NAME |
+| `rest-instance-swap-fixed-value` | LEDGERED | inversion-side | REST: a nested INSTANCE with a FIXED INSTANCE_SWAP value (componentProperties "Icon#3:1" = 9:9) and no host propRef | fixed prop values ride componentProperties (propose.ts COMPOSITION rule); the mapper skips INSTANCE_SWAP ("slots ride propRefs instead") so a fixed swap with no propRef vanishes |
+| `rest-instance-target-aspect-ratio` | LEDGERED | inversion-side | REST: a nested INSTANCE with a targetAspectRatio lock (16:16) | an aspect lock acts on resize; the code twin is aspect-ratio — carry it or name it |
+| `rest-item-reverse-z-index` | LEDGERED | inversion-side | REST: an auto-layout root with itemReverseZIndex true | paint order is a canvas fact with no dump field; render-inert without overlap but must be named, not dropped |
+| `rest-prototype-reaction` | LEDGERED | inversion-side | REST: an ON_HOVER → CHANGE_TO prototype reaction (interactions[] + transitionNodeID) on the root | the plugin dump names this class as prototype-reactions-unsupported (dump v1.27); the REST route must name it too — map.ts never reads interactions and no captureGap names prototypes |
+| `rest-slot-property-definition` | LEDGERED | inversion-side | REST: a native SLOT property definition whose defaultValue is an object ({guid}) and whose preferredValues name a COMPONENT_SET key | REST does return SLOT definitions with preferredValues (live probe 2026-08-22, file aekVseUceg35tVn62knRrj); the accepts list must be carried or named as "no in-scope contract for key" — not reported as "REST returns componentPropertyDefinitions EMPTY" |
+| `rest-swap-preferred-values-empty` | LEDGERED | inversion-side | REST: an INSTANCE_SWAP property whose preferredValues is an EMPTY list | an empty list is a fact (unconstrained swap), not an uncaptured one — the note must say unconstrained/empty rather than "not captured in dump v1" |
+| `rest-text-font-family` | LEDGERED | inversion-side | REST: a TEXT node in a non-default family (Manrope 700) | propose.ts declares font-family "never recoverable (everything renders Inter — fidelity scope)"; a declared limit must be a note in the report, not a source comment |
 | `rotation-nonshape` | LEDGERED | capture-side | rotation on a non-decor node (capture-boundary: rotation rides shape decor only) | the capture receipts rotation-unsupported; the node renders unrotated and nothing rotation-shaped may be invented |
 | `shape-vector-path` | LEDGERED | capture-side | a VECTOR child (arbitrary-path geometry) with a fill and a drawn fixed size | arbitrary paths are outside dump v1 (parametric decor only); the capture receipts vector-geometry-unsupported and the node carries paints + box only |
+| `slot-frame-child-default-content` | LEDGERED | inversion-side | dump: a native SLOT whose drawn content is a FRAME (holding an instance and a text), not a bare INSTANCE | the SLOTS rule carries an INSTANCE child as defaultContent; a FRAME child (and everything under it) is drawn content too and must be carried as a stub or named as dropped — never silent |
 | `stroke-align-center` | LEDGERED | capture-side | a stroke aligned CENTER (straddling the node box edge) | a centred stroke draws half its weight inside the box and half outside; CSS border draws wholly inward and outline wholly outward, so neither spelling carries it exactly. The capture receipts stroke-align-unsupported under its OWN code - not folded into stroke-style-unsupported, which is what made this boundary uncountable for eight rounds - and the inversion NAMES the approximation instead of proposing an outline it cannot justify |
 | `stroke-dashed` | LEDGERED | capture-side | a dashed stroke (dashPattern - capture-boundary) | dashed strokes have no dump v1 projection; the receipt names it and the stroke renders solid |
 | `stroke-weights-nonuniform` | LEDGERED | capture-side | per-side (non-uniform) stroke weights (capture-boundary: dump v1 carries a uniform weight only) | the capture receipts stroke-weights-nonuniform; the proposal must not invent per-side widths |
@@ -215,11 +227,125 @@ Carried, but not carried perfectly. These are the classes an adopter will actual
 
 ---
 
-## 5. The work order
+## 5. The pinned reds, and the work order
 
 ### 5.1 The pinned reds
 
-NONE. All 116 conformance cases are green: every construct the documentation model says is CARRIED is carried, and every refusal is named. This section stays in the ledger because an empty pinned-red list is a reading, not a formatting accident — when a red returns it is printed here verbatim from the manifest.
+19 of the 135 conformance cases are FAIL-EXPECTED-RED: the documentation model says CARRIED, the engine does not deliver it, and the gap is pinned so it cannot be forgotten or quietly closed. Each is verbatim from the manifest.
+
+#### `axis-default-from-set` — expected CARRIED, inversion-side
+
+- **Construct:** dump: a VARIANT property definition whose declared defaultValue ("Lg") is NOT the first variant's value ("Sm")
+- **Why it should carry:** the set's defaultValue is the designer's declared default (dump v1.5 propertyDefinitions); the proposal must use it — not the first variant in tree order
+- **What actually happens:** SILENT — the proposal's prop default is the FIRST variant ("sm"); the declared defaultValue "Lg" is in the dump and contradicted with no note (Badge Size, Chip Dismissible, Heading Tag/Variant in the exam kit)
+
+#### `fill-absent-on-axis-value` — expected CARRIED, inversion-side
+
+- **Construct:** dump: a root fill present on every Size=Lg variant and absent on every Size=Sm variant (the Badge dot form)
+- **Why it should carry:** the stroke path already mints #00000000 for the ABSENT variants ("a strokeless node is a zero-width transparent stroke"); the fill path must carry background-color per axis the same way instead of dropping the whole channel as UNBOUND
+- **What actually happens:** NAMED-BUT-DROPPED — "UNBOUND Case:root fill — no token invented": the whole root background-color channel is gone for the variants that DO carry a fill (the Badge Default-size pill renders with no background)
+
+#### `fill-unset-by-state` — expected CARRIED, inversion-side
+
+- **Construct:** dump: a root fill present on Variant=Info (differing in Hover) and absent on Variant=Ghost
+- **Why it should carry:** the base background-color for the variants that HAVE a fill is a measured fact; one variant without a fill must not erase the channel for the others (the Button lost its background entirely)
+- **What actually happens:** NAMED-BUT-DROPPED — "fill differs in state hover but is absent in some of its variant(s) — a state override cannot unset a channel; NAMED, not proposed" plus UNBOUND: the base background-color for Info is dropped too (the Button renders with no fill)
+
+#### `grid-root-hug-height-fixed-conflict` — expected CARRIED, inversion-side
+
+- **Construct:** dump: a GRID root with a single {fit} row (height HUGS its content) that the REST mapper spells primarySizing FIXED with a bbox
+- **Why it should carry:** a root height has ONE spelling; the emitter refuses a part that carries height as both a literal and a token (the generate step refused the whole batch on this)
+- **What actually happens:** DOUBLE-SPELLING — the root carries literals.height "fit-content" (G8, drawn HUG) AND tokens.height {imported.case.root.height} = 95px (from bbox, "DRAWN FIXED"); the emitter refuses the contract by name (Section Header/Footer blocked the whole generate batch)
+
+#### `rest-child-frame-fixed-size` — expected CARRIED, inversion-side
+
+- **Construct:** REST: a child FRAME drawn FIXED at 20×20 (layoutSizingHorizontal/Vertical FIXED) inside a HUG root
+- **Why it should carry:** a drawn fixed size on a frame is a design value (icon wrapper); the captureGap names fixed sizes on RECTANGLES only, and a FRAME has no bbox on this route
+- **What actually happens:** SILENT — a FIXED child FRAME has no width/height/bbox in the REST dump (bbox rides instances and roots only); the 20×20 box sizes to content and nothing says so
+
+#### `rest-effect-bound-variables` — expected LEDGERED, inversion-side
+
+- **Construct:** REST: a DROP_SHADOW whose radius/spread/color/offset are bound to variables, with no variables response
+- **Why it should carry:** every other bound channel degrades to its literal under a named variable-unresolved receipt; an effect binding must get the same receipt — BOUND_FIELDS_SKIPPED silences "effects" and the effect mapper reads no boundVariables
+- **What actually happens:** SILENT — the shadow carries as a literal box-shadow; no variable-unresolved receipt for the five effect aliases (BOUND_FIELDS_SKIPPED "effects")
+
+#### `rest-effect-style-identity` — expected LEDGERED, inversion-side
+
+- **Construct:** REST: a DROP_SHADOW on the root that rides an EFFECT style (node.styles.effect + styles metadata name "shadow/md")
+- **Why it should carry:** the shadow geometry carries as box-shadow; the STYLE identity is a token-class fact (the same way text.style carries a TextStyle name) and must be carried or named — map.ts reads styles.text only
+- **What actually happens:** SILENT — box-shadow carries, nothing names the effect style id/name (map.ts reads styles.text only)
+
+#### `rest-instance-fill-override` — expected LEDGERED, inversion-side
+
+- **Construct:** REST: a nested INSTANCE whose internal vector fill is OVERRIDDEN by the host (overrides[].overriddenFields includes "fills")
+- **Why it should carry:** instance internals are elided by rule, but a HOST override is a host fact (the icon colour per variant) and must be named
+- **What actually happens:** SILENT — overrides[] is never read; the only "override" in the union is the generic read-limit note about TEXT overrides
+
+#### `rest-instance-slot-prop-value` — expected LEDGERED, inversion-side
+
+- **Construct:** REST: a nested INSTANCE with a SLOT-typed property value ({guid}) in componentProperties
+- **Why it should carry:** an object is not a prop value the contract grammar can hold (exact mode crashed on Card Grid with a ContractSchema error); it must be dropped BY NAME
+- **What actually happens:** WHOLE-SET REFUSAL — the {guid} value reaches ContractSchema and the entire set is skipped ("did not fit the contract schema … unrecognized key guid"); named, but one nested prop value costs the whole component (Card Grid in exact mode)
+
+#### `rest-instance-swap-fixed-value` — expected LEDGERED, inversion-side
+
+- **Construct:** REST: a nested INSTANCE with a FIXED INSTANCE_SWAP value (componentProperties "Icon#3:1" = 9:9) and no host propRef
+- **Why it should carry:** fixed prop values ride componentProperties (propose.ts COMPOSITION rule); the mapper skips INSTANCE_SWAP ("slots ride propRefs instead") so a fixed swap with no propRef vanishes
+- **What actually happens:** SILENT — the VARIANT prop canonicalizes ({"state":"default"}); the INSTANCE_SWAP value is skipped in mapInstance (`continue`) and no note names "Icon"
+
+#### `rest-instance-target-aspect-ratio` — expected LEDGERED, inversion-side
+
+- **Construct:** REST: a nested INSTANCE with a targetAspectRatio lock (16:16)
+- **Why it should carry:** an aspect lock acts on resize; the code twin is aspect-ratio — carry it or name it
+- **What actually happens:** SILENT — targetAspectRatio is never read; the stub carries the observed 16×16 box only
+
+#### `rest-item-reverse-z-index` — expected LEDGERED, inversion-side
+
+- **Construct:** REST: an auto-layout root with itemReverseZIndex true
+- **Why it should carry:** paint order is a canvas fact with no dump field; render-inert without overlap but must be named, not dropped
+- **What actually happens:** SILENT — itemReverseZIndex is never read (render-inert without overlapping children, still a dropped fact)
+
+#### `rest-layout-sizing-vertical-fill` — expected CARRIED, inversion-side
+
+- **Construct:** REST: a child FRAME with layoutSizingVertical FILL inside a fixed-height ROW root
+- **Why it should carry:** cross-axis fill is the artifact of align:stretch on the parent (propose.ts LAYOUT rule) — the vertical twin of fillWidth must invert the same way
+- **What actually happens:** SILENT — only layoutSizingHorizontal FILL maps (fillWidth); the vertical FILL child leaves no align:stretch and no note
+
+#### `rest-prototype-reaction` — expected LEDGERED, inversion-side
+
+- **Construct:** REST: an ON_HOVER → CHANGE_TO prototype reaction (interactions[] + transitionNodeID) on the root
+- **Why it should carry:** the plugin dump names this class as prototype-reactions-unsupported (dump v1.27); the REST route must name it too — map.ts never reads interactions and no captureGap names prototypes
+- **What actually happens:** SILENT — interactions/transitionNodeID are never read on the REST route; no note, no captureGap
+
+#### `rest-slot-property-definition` — expected LEDGERED, inversion-side
+
+- **Construct:** REST: a native SLOT property definition whose defaultValue is an object ({guid}) and whose preferredValues name a COMPONENT_SET key
+- **Why it should carry:** REST does return SLOT definitions with preferredValues (live probe 2026-08-22, file aekVseUceg35tVn62knRrj); the accepts list must be carried or named as "no in-scope contract for key" — not reported as "REST returns componentPropertyDefinitions EMPTY"
+- **What actually happens:** WRONG-NAME — map.ts drops a SLOT definition whose defaultValue is an object ({guid}); propose then reports "REST returns componentPropertyDefinitions EMPTY for SLOT properties", which the live response contradicts (the definition and its preferredValues were returned)
+
+#### `rest-swap-preferred-values-empty` — expected LEDGERED, inversion-side
+
+- **Construct:** REST: an INSTANCE_SWAP property whose preferredValues is an EMPTY list
+- **Why it should carry:** an empty list is a fact (unconstrained swap), not an uncaptured one — the note must say unconstrained/empty rather than "not captured in dump v1"
+- **What actually happens:** WRONG-NAME — the mapper stores preferredValues only when non-empty; propose reports the empty list as "not captured in dump v1"
+
+#### `rest-text-align-center` — expected CARRIED, inversion-side
+
+- **Construct:** REST: a fixed-width TEXT node with textAlignHorizontal CENTER
+- **Why it should carry:** text-align is a declared CSS channel with a 1:1 canvas fact; map.ts never reads textAlignHorizontal
+- **What actually happens:** SILENT — textAlignHorizontal is never read; no text-align in the contract, no note
+
+#### `rest-text-font-family` — expected LEDGERED, inversion-side
+
+- **Construct:** REST: a TEXT node in a non-default family (Manrope 700)
+- **Why it should carry:** propose.ts declares font-family "never recoverable (everything renders Inter — fidelity scope)"; a declared limit must be a note in the report, not a source comment
+- **What actually happens:** SILENT — DumpText has no fontFamily field; Manrope 700 degrades to the emitter default family with no note
+
+#### `slot-frame-child-default-content` — expected LEDGERED, inversion-side
+
+- **Construct:** dump: a native SLOT whose drawn content is a FRAME (holding an instance and a text), not a bare INSTANCE
+- **Why it should carry:** the SLOTS rule carries an INSTANCE child as defaultContent; a FRAME child (and everything under it) is drawn content too and must be carried as a stub or named as dropped — never silent
+- **What actually happens:** SILENT — the slot part is proposed with NO defaultContent; the FRAME child "a" (with its Chip instance and text) vanishes with no note
 
 ### 5.2 The round-1 audit, re-checked
 
@@ -258,11 +384,12 @@ Named holes, so that no reader mistakes an absence for a zero.
 ### 5.4 The work order, in the order it pays
 
 1. **The paste door is OPEN** (§3.4) — closed for two rounds, and the two blockers that held it (an empty `base` tokenSet refused outright, and `social-button`'s `{platform}` icon ref read as a literal filename) are both fixed and pinned by `npm run paste:check`, which drives the REAL referee for this kit and for a variable-publishing one. An adopter can now take these 15 contracts through the shipping path unaided. What ranks first NOW is below.
-2. **variant-name-transliteration-api** — OPEN, mint stage (inversion-side). 1 reserved-name collision (SocialIcon.style); 11 props whose enum still spells `'false'` instead of absence/boolean; 3 numeric-valued string enums (ProgressBar.progress, Slider.leftControl, Slider.rightControl).
-3. **duplicate-parts-from-wrapper-union** — PARTIAL, propose-invert stage (inversion-side). 3 numbered part names whose base name is also a part of the same contract (progress-bar.Progress2, slider.leftControl2, slider.rightControl2); the audited duplicates (ProgressCircle's four label parts, DropdownListItem's Text2/Checkbox×2/circle×2, InputFieldBase's tripled trailing icons) are all absent. The probe cannot prove the residuals are not genuine sibling nodes.
-4. **ua-default-leakage** — PARTIAL, emit-react stage (emitter-side). global `box-sizing: border-box` reset in tokens.css: present; 8/30 emitted `.root` rules set a background explicitly. No `appearance:` reset exists anywhere in the emitted CSS (1 files).
-5. **story-space-mismatch** — PARTIAL, story-gen stage (emitter-side). 14/15 sets enumerate exactly the variants the capture holds; disagreements: progress-circle 20 enumerated vs 16 captured. Story files are generated per set (30 of 30 emitted components ship stories).
-6. **Classify the 0 untagged round-trip facts** (§5.3) — until divergence and loss are classified the way invention already is, no blast-radius number in §4 can claim to be complete.
+2. **The 19 pinned reds** (§5.1) — `axis-default-from-set`, `fill-absent-on-axis-value`, `fill-unset-by-state`, `grid-root-hug-height-fixed-conflict`, `rest-child-frame-fixed-size`, `rest-effect-bound-variables`, `rest-effect-style-identity`, `rest-instance-fill-override`, `rest-instance-slot-prop-value`, `rest-instance-swap-fixed-value`, `rest-instance-target-aspect-ratio`, `rest-item-reverse-z-index`, `rest-layout-sizing-vertical-fill`, `rest-prototype-reaction`, `rest-slot-property-definition`, `rest-swap-preferred-values-empty`, `rest-text-align-center`, `rest-text-font-family`, `slot-frame-child-default-content`. A pinned red outranks every OPEN class below it: the documentation model says the construct is CARRIED and the engine does not deliver it, which is the one failure this project treats as a bug rather than a boundary.
+3. **variant-name-transliteration-api** — OPEN, mint stage (inversion-side). 1 reserved-name collision (SocialIcon.style); 11 props whose enum still spells `'false'` instead of absence/boolean; 3 numeric-valued string enums (ProgressBar.progress, Slider.leftControl, Slider.rightControl).
+4. **duplicate-parts-from-wrapper-union** — PARTIAL, propose-invert stage (inversion-side). 3 numbered part names whose base name is also a part of the same contract (progress-bar.Progress2, slider.leftControl2, slider.rightControl2); the audited duplicates (ProgressCircle's four label parts, DropdownListItem's Text2/Checkbox×2/circle×2, InputFieldBase's tripled trailing icons) are all absent. The probe cannot prove the residuals are not genuine sibling nodes.
+5. **ua-default-leakage** — PARTIAL, emit-react stage (emitter-side). global `box-sizing: border-box` reset in tokens.css: present; 8/30 emitted `.root` rules set a background explicitly. No `appearance:` reset exists anywhere in the emitted CSS (1 files).
+6. **story-space-mismatch** — PARTIAL, story-gen stage (emitter-side). 14/15 sets enumerate exactly the variants the capture holds; disagreements: progress-circle 20 enumerated vs 16 captured. Story files are generated per set (30 of 30 emitted components ship stories).
+7. **Classify the 0 untagged round-trip facts** (§5.3) — until divergence and loss are classified the way invention already is, no blast-radius number in §4 can claim to be complete.
 
 ---
 
@@ -274,7 +401,7 @@ npx tsx extract/figma/ledger/build.ts
 
 # 2 · the document-model fixture — fast, read-only, no engine changes
 npm run conformance:canvas
-#    expect: 116 case(s): 116 PASS, 0 RED-EXPECTED (pinned findings), 0 FAIL, 0 UNEXPECTED-GREEN, 0 UNLISTED, 0 MISSING
+#    expect: 135 case(s): 116 PASS, 19 RED-EXPECTED (pinned findings), 0 FAIL, 0 UNEXPECTED-GREEN, 0 UNLISTED, 0 MISSING
 
 # 3 · the canvas→code→canvas round trip (rewrites REPORT.md + report.json)
 npm run extract:figma:roundtrip:uui
@@ -299,7 +426,7 @@ npx tsx examples/untitled-ui/fidelity-score.mts
 | `examples/untitled-ui/storybook/contracts/` | `63f093f001fb` | 129,887 | proposed contracts (30 files) |
 | `examples/untitled-ui/storybook/src/generated/` | `be9c86b4f480` | 275,818 | emitted components (30 dirs) |
 | `examples/untitled-ui/storybook/src/tokens.css` | `8c31938a1627` | 674,804 | emitted global tokens |
-| `extract/figma/conformance/MANIFEST.json` | `71392fbbb21e` | 67,755 | conformance denominator |
+| `extract/figma/conformance/MANIFEST.json` | `9c2374097aba` | 86,207 | conformance denominator |
 | `extract/figma/roundtrip-uui/report.json` | `3f4d66b6b63c` | 7,704,705 | round-trip facts |
 | `extract/figma/roundtrip-uui/REPORT.md` | `61f5c58f7f20` | 144,788 | round-trip narrative |
 

--- a/examples/untitled-ui/RESIDUALS.md
+++ b/examples/untitled-ui/RESIDUALS.md
@@ -304,7 +304,7 @@ What each would need in order to stop costing pixels, quoted from the receipt th
 
 ### 5.4 Refusals that are structural given the contract vocabulary
 
-The conformance manifest names **9 constructs REFUSED** and **14 LEDGERED** — the vocabulary boundary itself, hand-authored from Figma's documentation model rather than from engine output. A refusal is closable only by a VOCABULARY change, which is a different kind of round from a defect fix.
+The conformance manifest names **9 constructs REFUSED** and **26 LEDGERED** — the vocabulary boundary itself, hand-authored from Figma's documentation model rather than from engine output. A refusal is closable only by a VOCABULARY change, which is a different kind of round from a defect fix.
 
 | case | the construct | the vocabulary change it would need |
 |---|---|---|
@@ -324,8 +324,20 @@ The conformance manifest names **9 constructs REFUSED** and **14 LEDGERED** — 
 | `instance-override-paint-observed` | an observed subtree paint on an instance LINKED to a real contract (classic path, no instanceOverrides ledger) | the child contract owns its paint; a per-usage override is not representable on a component ref without the opt-in override machinery - ledgered by name |
 | `placement-constraints-scale` | an ABSOLUTE child whose constraints are SCALE x SCALE | SCALE placement has no carried offset spelling (a stretch percentage, not an offset); must be a named refusal, the part renders in flow |
 | `radius-per-corner` | per-corner (non-uniform) radii (capture-boundary: dump v1 carries a uniform radius only) | the capture receipts radii-nonuniform; nothing corner-shaped may be invented |
+| `rest-effect-bound-variables` | REST: a DROP_SHADOW whose radius/spread/color/offset are bound to variables, with no variables response | every other bound channel degrades to its literal under a named variable-unresolved receipt; an effect binding must get the same receipt — BOUND_FIELDS_SKIPPED silences "effects" and the effect mapper reads no boundVariables |
+| `rest-effect-style-identity` | REST: a DROP_SHADOW on the root that rides an EFFECT style (node.styles.effect + styles metadata name "shadow/md") | the shadow geometry carries as box-shadow; the STYLE identity is a token-class fact (the same way text.style carries a TextStyle name) and must be carried or named — map.ts reads styles.text only |
+| `rest-instance-fill-override` | REST: a nested INSTANCE whose internal vector fill is OVERRIDDEN by the host (overrides[].overriddenFields includes "fills") | instance internals are elided by rule, but a HOST override is a host fact (the icon colour per variant) and must be named |
+| `rest-instance-slot-prop-value` | REST: a nested INSTANCE with a SLOT-typed property value ({guid}) in componentProperties | an object is not a prop value the contract grammar can hold (exact mode crashed on Card Grid with a ContractSchema error); it must be dropped BY NAME |
+| `rest-instance-swap-fixed-value` | REST: a nested INSTANCE with a FIXED INSTANCE_SWAP value (componentProperties "Icon#3:1" = 9:9) and no host propRef | fixed prop values ride componentProperties (propose.ts COMPOSITION rule); the mapper skips INSTANCE_SWAP ("slots ride propRefs instead") so a fixed swap with no propRef vanishes |
+| `rest-instance-target-aspect-ratio` | REST: a nested INSTANCE with a targetAspectRatio lock (16:16) | an aspect lock acts on resize; the code twin is aspect-ratio — carry it or name it |
+| `rest-item-reverse-z-index` | REST: an auto-layout root with itemReverseZIndex true | paint order is a canvas fact with no dump field; render-inert without overlap but must be named, not dropped |
+| `rest-prototype-reaction` | REST: an ON_HOVER → CHANGE_TO prototype reaction (interactions[] + transitionNodeID) on the root | the plugin dump names this class as prototype-reactions-unsupported (dump v1.27); the REST route must name it too — map.ts never reads interactions and no captureGap names prototypes |
+| `rest-slot-property-definition` | REST: a native SLOT property definition whose defaultValue is an object ({guid}) and whose preferredValues name a COMPONENT_SET key | REST does return SLOT definitions with preferredValues (live probe 2026-08-22, file aekVseUceg35tVn62knRrj); the accepts list must be carried or named as "no in-scope contract for key" — not reported as "REST returns componentPropertyDefinitions EMPTY" |
+| `rest-swap-preferred-values-empty` | REST: an INSTANCE_SWAP property whose preferredValues is an EMPTY list | an empty list is a fact (unconstrained swap), not an uncaptured one — the note must say unconstrained/empty rather than "not captured in dump v1" |
+| `rest-text-font-family` | REST: a TEXT node in a non-default family (Manrope 700) | propose.ts declares font-family "never recoverable (everything renders Inter — fidelity scope)"; a declared limit must be a note in the report, not a source comment |
 | `rotation-nonshape` | rotation on a non-decor node (capture-boundary: rotation rides shape decor only) | the capture receipts rotation-unsupported; the node renders unrotated and nothing rotation-shaped may be invented |
 | `shape-vector-path` | a VECTOR child (arbitrary-path geometry) with a fill and a drawn fixed size | arbitrary paths are outside dump v1 (parametric decor only); the capture receipts vector-geometry-unsupported and the node carries paints + box only |
+| `slot-frame-child-default-content` | dump: a native SLOT whose drawn content is a FRAME (holding an instance and a text), not a bare INSTANCE | the SLOTS rule carries an INSTANCE child as defaultContent; a FRAME child (and everything under it) is drawn content too and must be carried as a stub or named as dropped — never silent |
 | `slot-preferred-unresolvable` | preferredValues naming a key with NO in-scope contract | unresolvable keys are named, never guessed into ids - accepts stays unauthored |
 | `stroke-align-center` | a stroke aligned CENTER (straddling the node box edge) | a centred stroke draws half its weight inside the box and half outside; CSS border draws wholly inward and outline wholly outward, so neither spelling carries it exactly. The capture receipts stroke-align-unsupported under its OWN code - not folded into stroke-style-unsupported, which is what made this boundary uncountable for eight rounds - and the inversion NAMES the approximation instead of proposing an outline it cannot justify |
 | `stroke-dashed` | a dashed stroke (dashPattern - capture-boundary) | dashed strokes have no dump v1 projection; the receipt names it and the stroke renders solid |
@@ -457,7 +469,7 @@ None of the three steps rewrites `renders/FIDELITY.md`, `renders/fidelity.json` 
 | `examples/untitled-ui/renders/fidelity.json` | `0a468d6682bf` | 84,415 | fidelity table |
 | `examples/untitled-ui/renders/FIDELITY.md` | `3b0532cd2de8` | 4,242 | fidelity method |
 | `examples/untitled-ui/storybook/contracts/` | `63f093f001fb` | 129,887 | proposed contracts (30 files) |
-| `extract/figma/conformance/MANIFEST.json` | `71392fbbb21e` | 67,755 | conformance denominator |
+| `extract/figma/conformance/MANIFEST.json` | `9c2374097aba` | 86,207 | conformance denominator |
 | `extract/figma/roundtrip-uui/report.json` | `3f4d66b6b63c` | 7,704,705 | round-trip facts |
 
 Same bytes in, same file out: this build reads no clock, no git state and no environment, and sorts every collection before rendering.

--- a/extract/figma/conformance/MANIFEST.json
+++ b/extract/figma/conformance/MANIFEST.json
@@ -1607,6 +1607,419 @@
         ]
       },
       "status": "green"
+    },
+    {
+      "id": "rest-effect-style-identity",
+      "construct": "REST: a DROP_SHADOW on the root that rides an EFFECT style (node.styles.effect + styles metadata name \"shadow/md\")",
+      "expect": "LEDGERED",
+      "why": "the shadow geometry carries as box-shadow; the STYLE identity is a token-class fact (the same way text.style carries a TextStyle name) and must be carried or named — map.ts reads styles.text only",
+      "check": {
+        "carried": [
+          "box-shadow"
+        ],
+        "note": "effect style|shadow/md"
+      },
+      "status": "red",
+      "observed": "SILENT — box-shadow carries, nothing names the effect style id/name (map.ts reads styles.text only)",
+      "observedCheck": {
+        "carried": [
+          "box-shadow"
+        ],
+        "noteAbsent": [
+          "effect style",
+          "shadow/md"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "rest-effect-bound-variables",
+      "construct": "REST: a DROP_SHADOW whose radius/spread/color/offset are bound to variables, with no variables response",
+      "expect": "LEDGERED",
+      "why": "every other bound channel degrades to its literal under a named variable-unresolved receipt; an effect binding must get the same receipt — BOUND_FIELDS_SKIPPED silences \"effects\" and the effect mapper reads no boundVariables",
+      "check": {
+        "carried": [
+          "box-shadow"
+        ],
+        "note": "variable-unresolved @ Case:Case effects|effect.*variable"
+      },
+      "status": "red",
+      "observed": "SILENT — the shadow carries as a literal box-shadow; no variable-unresolved receipt for the five effect aliases (BOUND_FIELDS_SKIPPED \"effects\")",
+      "observedCheck": {
+        "carried": [
+          "box-shadow"
+        ],
+        "noteAbsent": [
+          "variable-unresolved @ Case:Case effects",
+          "effect.*variable"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "rest-prototype-reaction",
+      "construct": "REST: an ON_HOVER → CHANGE_TO prototype reaction (interactions[] + transitionNodeID) on the root",
+      "expect": "LEDGERED",
+      "why": "the plugin dump names this class as prototype-reactions-unsupported (dump v1.27); the REST route must name it too — map.ts never reads interactions and no captureGap names prototypes",
+      "check": {
+        "note": "prototype-reactions-unsupported|ON_HOVER|reaction"
+      },
+      "status": "red",
+      "observed": "SILENT — interactions/transitionNodeID are never read on the REST route; no note, no captureGap",
+      "observedCheck": {
+        "noteAbsent": [
+          "prototype-reactions-unsupported",
+          "ON_HOVER",
+          "reaction"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "rest-slot-property-definition",
+      "construct": "REST: a native SLOT property definition whose defaultValue is an object ({guid}) and whose preferredValues name a COMPONENT_SET key",
+      "expect": "LEDGERED",
+      "why": "REST does return SLOT definitions with preferredValues (live probe 2026-08-22, file aekVseUceg35tVn62knRrj); the accepts list must be carried or named as \"no in-scope contract for key\" — not reported as \"REST returns componentPropertyDefinitions EMPTY\"",
+      "check": {
+        "carried": [
+          "\"slot\""
+        ],
+        "note": "preferredValues name 1 component key\\(s\\) with no in-scope contract",
+        "noteAbsent": [
+          "REST returns componentPropertyDefinitions EMPTY"
+        ]
+      },
+      "status": "red",
+      "observed": "WRONG-NAME — map.ts drops a SLOT definition whose defaultValue is an object ({guid}); propose then reports \"REST returns componentPropertyDefinitions EMPTY for SLOT properties\", which the live response contradicts (the definition and its preferredValues were returned)",
+      "observedCheck": {
+        "carried": [
+          "\"slot\""
+        ],
+        "note": "REST returns componentPropertyDefinitions EMPTY",
+        "noteAbsent": [
+          "no in-scope contract"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "rest-swap-preferred-values-empty",
+      "construct": "REST: an INSTANCE_SWAP property whose preferredValues is an EMPTY list",
+      "expect": "LEDGERED",
+      "why": "an empty list is a fact (unconstrained swap), not an uncaptured one — the note must say unconstrained/empty rather than \"not captured in dump v1\"",
+      "check": {
+        "carried": [
+          "\"slot\""
+        ],
+        "note": "preferredValues.*(empty|unconstrained|\\[\\])",
+        "noteAbsent": [
+          "not captured in dump v1"
+        ]
+      },
+      "status": "red",
+      "observed": "WRONG-NAME — the mapper stores preferredValues only when non-empty; propose reports the empty list as \"not captured in dump v1\"",
+      "observedCheck": {
+        "carried": [
+          "\"slot\""
+        ],
+        "note": "not captured in dump v1"
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "rest-layout-sizing-vertical-fill",
+      "construct": "REST: a child FRAME with layoutSizingVertical FILL inside a fixed-height ROW root",
+      "expect": "CARRIED",
+      "why": "cross-axis fill is the artifact of align:stretch on the parent (propose.ts LAYOUT rule) — the vertical twin of fillWidth must invert the same way",
+      "check": {
+        "carried": [
+          "\"align\":\"stretch\""
+        ]
+      },
+      "status": "red",
+      "observed": "SILENT — only layoutSizingHorizontal FILL maps (fillWidth); the vertical FILL child leaves no align:stretch and no note",
+      "observedCheck": {
+        "absent": [
+          "\"align\":\"stretch\""
+        ],
+        "noteAbsent": [
+          "Case:root/a: .*(FILL|fill|stretch)"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "rest-child-frame-fixed-size",
+      "construct": "REST: a child FRAME drawn FIXED at 20×20 (layoutSizingHorizontal/Vertical FIXED) inside a HUG root",
+      "expect": "CARRIED",
+      "why": "a drawn fixed size on a frame is a design value (icon wrapper); the captureGap names fixed sizes on RECTANGLES only, and a FRAME has no bbox on this route",
+      "check": {
+        "carried": [
+          "imported\\.(case\\.a\\.(width|height)|shared\\.size-20)"
+        ]
+      },
+      "status": "red",
+      "observed": "SILENT — a FIXED child FRAME has no width/height/bbox in the REST dump (bbox rides instances and roots only); the 20×20 box sizes to content and nothing says so",
+      "observedCheck": {
+        "absent": [
+          "imported\\.case\\.a\\.(width|height)",
+          "imported\\.shared\\.size-20"
+        ],
+        "noteAbsent": [
+          "Case:root/a: .*(fixed|FIXED|20px)"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "rest-instance-fill-override",
+      "construct": "REST: a nested INSTANCE whose internal vector fill is OVERRIDDEN by the host (overrides[].overriddenFields includes \"fills\")",
+      "expect": "LEDGERED",
+      "why": "instance internals are elided by rule, but a HOST override is a host fact (the icon colour per variant) and must be named",
+      "check": {
+        "note": "fill override|overridden|host override"
+      },
+      "status": "red",
+      "observed": "SILENT — overrides[] is never read; the only \"override\" in the union is the generic read-limit note about TEXT overrides",
+      "observedCheck": {
+        "noteAbsent": [
+          "fill override",
+          "overridden",
+          "host override"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "rest-instance-swap-fixed-value",
+      "construct": "REST: a nested INSTANCE with a FIXED INSTANCE_SWAP value (componentProperties \"Icon#3:1\" = 9:9) and no host propRef",
+      "expect": "LEDGERED",
+      "why": "fixed prop values ride componentProperties (propose.ts COMPOSITION rule); the mapper skips INSTANCE_SWAP (\"slots ride propRefs instead\") so a fixed swap with no propRef vanishes",
+      "check": {
+        "note": "Icon"
+      },
+      "status": "red",
+      "observed": "SILENT — the VARIANT prop canonicalizes ({\"state\":\"default\"}); the INSTANCE_SWAP value is skipped in mapInstance (`continue`) and no note names \"Icon\"",
+      "observedCheck": {
+        "carried": [
+          "\"props\":\\{\"state\":\"default\"\\}"
+        ],
+        "noteAbsent": [
+          "Icon"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "rest-instance-slot-prop-value",
+      "construct": "REST: a nested INSTANCE with a SLOT-typed property value ({guid}) in componentProperties",
+      "expect": "LEDGERED",
+      "why": "an object is not a prop value the contract grammar can hold (exact mode crashed on Card Grid with a ContractSchema error); it must be dropped BY NAME",
+      "check": {
+        "carried": [
+          "\"id\":\"ds.case\""
+        ],
+        "note": "Items|SLOT",
+        "absent": [
+          "guid"
+        ]
+      },
+      "status": "red",
+      "observed": "WHOLE-SET REFUSAL — the {guid} value reaches ContractSchema and the entire set is skipped (\"did not fit the contract schema … unrecognized key guid\"); named, but one nested prop value costs the whole component (Card Grid in exact mode)",
+      "observedCheck": {
+        "note": "could not be proposed: the proposed contract did not fit the contract schema",
+        "absent": [
+          "\"id\":\"ds.case\""
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "rest-text-font-family",
+      "construct": "REST: a TEXT node in a non-default family (Manrope 700)",
+      "expect": "LEDGERED",
+      "why": "propose.ts declares font-family \"never recoverable (everything renders Inter — fidelity scope)\"; a declared limit must be a note in the report, not a source comment",
+      "check": {
+        "note": "font-family|fontFamily|Manrope"
+      },
+      "status": "red",
+      "observed": "SILENT — DumpText has no fontFamily field; Manrope 700 degrades to the emitter default family with no note",
+      "observedCheck": {
+        "noteAbsent": [
+          "font-family",
+          "fontFamily",
+          "Manrope"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "rest-text-align-center",
+      "construct": "REST: a fixed-width TEXT node with textAlignHorizontal CENTER",
+      "expect": "CARRIED",
+      "why": "text-align is a declared CSS channel with a 1:1 canvas fact; map.ts never reads textAlignHorizontal",
+      "check": {
+        "carried": [
+          "text-align"
+        ]
+      },
+      "status": "red",
+      "observed": "SILENT — textAlignHorizontal is never read; no text-align in the contract, no note",
+      "observedCheck": {
+        "absent": [
+          "text-align"
+        ],
+        "noteAbsent": [
+          "text-align",
+          "textAlign"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "rest-item-reverse-z-index",
+      "construct": "REST: an auto-layout root with itemReverseZIndex true",
+      "expect": "LEDGERED",
+      "why": "paint order is a canvas fact with no dump field; render-inert without overlap but must be named, not dropped",
+      "check": {
+        "note": "itemReverseZIndex|z-index|paint order"
+      },
+      "status": "red",
+      "observed": "SILENT — itemReverseZIndex is never read (render-inert without overlapping children, still a dropped fact)",
+      "observedCheck": {
+        "noteAbsent": [
+          "itemReverseZIndex",
+          "z-index",
+          "paint order"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "rest-instance-target-aspect-ratio",
+      "construct": "REST: a nested INSTANCE with a targetAspectRatio lock (16:16)",
+      "expect": "LEDGERED",
+      "why": "an aspect lock acts on resize; the code twin is aspect-ratio — carry it or name it",
+      "check": {
+        "note": "aspect"
+      },
+      "status": "red",
+      "observed": "SILENT — targetAspectRatio is never read; the stub carries the observed 16×16 box only",
+      "observedCheck": {
+        "carried": [
+          "imported\\.stub-glyph\\.root\\.width"
+        ],
+        "noteAbsent": [
+          "aspect"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "axis-default-from-set",
+      "construct": "dump: a VARIANT property definition whose declared defaultValue (\"Lg\") is NOT the first variant's value (\"Sm\")",
+      "expect": "CARRIED",
+      "why": "the set's defaultValue is the designer's declared default (dump v1.5 propertyDefinitions); the proposal must use it — not the first variant in tree order",
+      "check": {
+        "carried": [
+          "\"name\":\"size\".{0,80}\"default\":\"lg\""
+        ]
+      },
+      "status": "red",
+      "observed": "SILENT — the proposal's prop default is the FIRST variant (\"sm\"); the declared defaultValue \"Lg\" is in the dump and contradicted with no note (Badge Size, Chip Dismissible, Heading Tag/Variant in the exam kit)",
+      "observedCheck": {
+        "carried": [
+          "\"name\":\"size\".{0,80}\"default\":\"sm\""
+        ],
+        "noteAbsent": [
+          "defaultValue"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "fill-absent-on-axis-value",
+      "construct": "dump: a root fill present on every Size=Lg variant and absent on every Size=Sm variant (the Badge dot form)",
+      "expect": "CARRIED",
+      "why": "the stroke path already mints #00000000 for the ABSENT variants (\"a strokeless node is a zero-width transparent stroke\"); the fill path must carry background-color per axis the same way instead of dropping the whole channel as UNBOUND",
+      "check": {
+        "carried": [
+          "imported\\.case\\.root\\.background-color"
+        ]
+      },
+      "status": "red",
+      "observed": "NAMED-BUT-DROPPED — \"UNBOUND Case:root fill — no token invented\": the whole root background-color channel is gone for the variants that DO carry a fill (the Badge Default-size pill renders with no background)",
+      "observedCheck": {
+        "note": "UNBOUND Case:root fill",
+        "absent": [
+          "imported\\.case\\.root\\.background-color"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "fill-unset-by-state",
+      "construct": "dump: a root fill present on Variant=Info (differing in Hover) and absent on Variant=Ghost",
+      "expect": "CARRIED",
+      "why": "the base background-color for the variants that HAVE a fill is a measured fact; one variant without a fill must not erase the channel for the others (the Button lost its background entirely)",
+      "check": {
+        "carried": [
+          "imported\\.case\\.root\\.background-color"
+        ]
+      },
+      "status": "red",
+      "observed": "NAMED-BUT-DROPPED — \"fill differs in state hover but is absent in some of its variant(s) — a state override cannot unset a channel; NAMED, not proposed\" plus UNBOUND: the base background-color for Info is dropped too (the Button renders with no fill)",
+      "observedCheck": {
+        "note": "a state override cannot unset a channel",
+        "absent": [
+          "imported\\.case\\.root\\.background-color"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "slot-frame-child-default-content",
+      "construct": "dump: a native SLOT whose drawn content is a FRAME (holding an instance and a text), not a bare INSTANCE",
+      "expect": "LEDGERED",
+      "why": "the SLOTS rule carries an INSTANCE child as defaultContent; a FRAME child (and everything under it) is drawn content too and must be carried as a stub or named as dropped — never silent",
+      "check": {
+        "note": "\"s\".*\"a\"|slot \"s\".*(FRAME|frame)"
+      },
+      "status": "red",
+      "observed": "SILENT — the slot part is proposed with NO defaultContent; the FRAME child \"a\" (with its Chip instance and text) vanishes with no note",
+      "observedCheck": {
+        "absent": [
+          "defaultContent"
+        ],
+        "noteAbsent": [
+          "\"s\".*\"a\"",
+          "slot \"s\".*(FRAME|frame)"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
+    },
+    {
+      "id": "grid-root-hug-height-fixed-conflict",
+      "construct": "dump: a GRID root with a single {fit} row (height HUGS its content) that the REST mapper spells primarySizing FIXED with a bbox",
+      "expect": "CARRIED",
+      "why": "a root height has ONE spelling; the emitter refuses a part that carries height as both a literal and a token (the generate step refused the whole batch on this)",
+      "check": {
+        "carried": [
+          "\"height\":\"fit-content\""
+        ],
+        "absent": [
+          "imported\\.case\\.root\\.height"
+        ]
+      },
+      "status": "red",
+      "observed": "DOUBLE-SPELLING — the root carries literals.height \"fit-content\" (G8, drawn HUG) AND tokens.height {imported.case.root.height} = 95px (from bbox, \"DRAWN FIXED\"); the emitter refuses the contract by name (Section Header/Footer blocked the whole generate batch)",
+      "observedCheck": {
+        "carried": [
+          "\"height\":\"fit-content\"",
+          "imported\\.case\\.root\\.height"
+        ]
+      },
+      "exam": "phase-2 FIGMA-DS exam 2026-08-22 (parity/receipts/phase-2/FIGMA-DS-EXAM.md)"
     }
   ]
 }

--- a/extract/figma/conformance/README.md
+++ b/extract/figma/conformance/README.md
@@ -9,7 +9,13 @@ be measured in advance instead of discovered one Figma kit at a time.*
 
 - **Cases** are hand-authored dump v1 JSON (`cases/<id>.dump.json`) — the
   documented format of `extract/figma/types.ts`, the same bytes
-  `dump.plugin.js` produces. One SMALL, single-purpose case per construct:
+  `dump.plugin.js` produces. Since the Phase 2 exam (2026-08-22,
+  `parity/receipts/phase-2/FIGMA-DS-EXAM.md`) a case may instead enter at the
+  REST boundary as `cases/<id>.rest.json` — a `GET /v1/files/:key/nodes`
+  response, mapped through the real `extract/figma/rest/map.ts` (the Journey A
+  CLI's own transport); the mapper's MapReport joins the naming union exactly
+  as the CLI prints it, so a fact the mapper drops without a receipt is
+  measured as SILENT here, not as an absence of the dump grammar. One SMALL, single-purpose case per construct:
   auto-layout forms, paints, strokes, effects, text, radii, parametric decor
   shapes, absolute placement, variant axes (enum/bool/state/theme), nested
   instances, slots, spacers, wrapper artifacts, sparse presence,

--- a/extract/figma/conformance/cases/axis-default-from-set.dump.json
+++ b/extract/figma/conformance/cases/axis-default-from-set.dump.json
@@ -1,0 +1,97 @@
+{
+ "_provenance": {
+  "fileKey": null,
+  "dumpVersion": "1.9",
+  "note": "canvas conformance fixture - hand-authored dump v1.9 (Phase 2 exam)"
+ },
+ "Case": {
+  "setName": "Case",
+  "type": "COMPONENT_SET",
+  "propertyDefinitions": {
+   "Size": {
+    "type": "VARIANT",
+    "defaultValue": "Lg",
+    "variantOptions": [
+     "Sm",
+     "Lg"
+    ]
+   }
+  },
+  "variants": [
+   {
+    "name": "Size=Sm",
+    "type": "COMPONENT",
+    "layout": {
+     "mode": "HORIZONTAL",
+     "primary": "CENTER",
+     "counter": "CENTER",
+     "spacing": 0,
+     "padding": [
+      4,
+      12,
+      4,
+      12
+     ],
+     "primarySizing": "AUTO",
+     "counterSizing": "AUTO"
+    },
+    "fill": {
+     "var": "color/feedback/info/background"
+    },
+    "children": [
+     {
+      "name": "t",
+      "type": "TEXT",
+      "text": {
+       "characters": "Case",
+       "fontSize": 12,
+       "fontStyle": "Medium",
+       "style": "badge",
+       "fillVar": "color/feedback/info/foreground"
+      },
+      "fill": {
+       "var": "color/feedback/info/foreground"
+      }
+     }
+    ]
+   },
+   {
+    "name": "Size=Lg",
+    "type": "COMPONENT",
+    "layout": {
+     "mode": "HORIZONTAL",
+     "primary": "CENTER",
+     "counter": "CENTER",
+     "spacing": 0,
+     "padding": [
+      8,
+      16,
+      8,
+      16
+     ],
+     "primarySizing": "AUTO",
+     "counterSizing": "AUTO"
+    },
+    "fill": {
+     "var": "color/feedback/info/background"
+    },
+    "children": [
+     {
+      "name": "t",
+      "type": "TEXT",
+      "text": {
+       "characters": "Case",
+       "fontSize": 12,
+       "fontStyle": "Medium",
+       "style": "badge",
+       "fillVar": "color/feedback/info/foreground"
+      },
+      "fill": {
+       "var": "color/feedback/info/foreground"
+      }
+     }
+    ]
+   }
+  ]
+ }
+}

--- a/extract/figma/conformance/cases/fill-absent-on-axis-value.dump.json
+++ b/extract/figma/conformance/cases/fill-absent-on-axis-value.dump.json
@@ -1,0 +1,155 @@
+{
+ "_provenance": {
+  "fileKey": null,
+  "dumpVersion": "1.9",
+  "note": "canvas conformance fixture - hand-authored dump v1.9 (Phase 2 exam)"
+ },
+ "Case": {
+  "setName": "Case",
+  "type": "COMPONENT_SET",
+  "variants": [
+   {
+    "name": "Size=Sm, Variant=Info",
+    "type": "COMPONENT",
+    "layout": {
+     "mode": "HORIZONTAL",
+     "primary": "CENTER",
+     "counter": "CENTER",
+     "spacing": 0,
+     "padding": [
+      0,
+      0,
+      0,
+      0
+     ],
+     "primarySizing": "AUTO",
+     "counterSizing": "AUTO"
+    },
+    "cornerRadius": 9999,
+    "children": [
+     {
+      "name": "a",
+      "type": "ELLIPSE",
+      "fill": {
+       "var": "color/feedback/info/foreground"
+      },
+      "shape": {
+       "kind": "ellipse",
+       "width": 8,
+       "height": 8
+      }
+     }
+    ]
+   },
+   {
+    "name": "Size=Sm, Variant=Success",
+    "type": "COMPONENT",
+    "layout": {
+     "mode": "HORIZONTAL",
+     "primary": "CENTER",
+     "counter": "CENTER",
+     "spacing": 0,
+     "padding": [
+      0,
+      0,
+      0,
+      0
+     ],
+     "primarySizing": "AUTO",
+     "counterSizing": "AUTO"
+    },
+    "cornerRadius": 9999,
+    "children": [
+     {
+      "name": "a",
+      "type": "ELLIPSE",
+      "fill": {
+       "var": "color/feedback/success/foreground"
+      },
+      "shape": {
+       "kind": "ellipse",
+       "width": 8,
+       "height": 8
+      }
+     }
+    ]
+   },
+   {
+    "name": "Size=Lg, Variant=Info",
+    "type": "COMPONENT",
+    "layout": {
+     "mode": "HORIZONTAL",
+     "primary": "CENTER",
+     "counter": "CENTER",
+     "spacing": 0,
+     "padding": [
+      4,
+      12,
+      4,
+      12
+     ],
+     "primarySizing": "AUTO",
+     "counterSizing": "AUTO"
+    },
+    "cornerRadius": 8,
+    "fill": {
+     "hex": "b7e9c5"
+    },
+    "children": [
+     {
+      "name": "t",
+      "type": "TEXT",
+      "text": {
+       "characters": "Case",
+       "fontSize": 12,
+       "fontStyle": "Medium",
+       "style": "badge",
+       "fillVar": "color/feedback/info/foreground"
+      },
+      "fill": {
+       "var": "color/feedback/info/foreground"
+      }
+     }
+    ]
+   },
+   {
+    "name": "Size=Lg, Variant=Success",
+    "type": "COMPONENT",
+    "layout": {
+     "mode": "HORIZONTAL",
+     "primary": "CENTER",
+     "counter": "CENTER",
+     "spacing": 0,
+     "padding": [
+      4,
+      12,
+      4,
+      12
+     ],
+     "primarySizing": "AUTO",
+     "counterSizing": "AUTO"
+    },
+    "cornerRadius": 8,
+    "fill": {
+     "hex": "bfdfff"
+    },
+    "children": [
+     {
+      "name": "t",
+      "type": "TEXT",
+      "text": {
+       "characters": "Case",
+       "fontSize": 12,
+       "fontStyle": "Medium",
+       "style": "badge",
+       "fillVar": "color/feedback/success/foreground"
+      },
+      "fill": {
+       "var": "color/feedback/success/foreground"
+      }
+     }
+    ]
+   }
+  ]
+ }
+}

--- a/extract/figma/conformance/cases/fill-unset-by-state.dump.json
+++ b/extract/figma/conformance/cases/fill-unset-by-state.dump.json
@@ -1,0 +1,175 @@
+{
+ "_provenance": {
+  "fileKey": null,
+  "dumpVersion": "1.9",
+  "note": "canvas conformance fixture - hand-authored dump v1.9 (Phase 2 exam)"
+ },
+ "Case": {
+  "setName": "Case",
+  "type": "COMPONENT_SET",
+  "variants": [
+   {
+    "name": "Variant=Info, State=Default",
+    "type": "COMPONENT",
+    "layout": {
+     "mode": "HORIZONTAL",
+     "primary": "CENTER",
+     "counter": "CENTER",
+     "spacing": 0,
+     "padding": [
+      4,
+      12,
+      4,
+      12
+     ],
+     "primarySizing": "AUTO",
+     "counterSizing": "AUTO"
+    },
+    "cornerRadius": 8,
+    "fill": {
+     "hex": "8f8781"
+    },
+    "stroke": {
+     "var": "color/feedback/info/foreground"
+    },
+    "strokeWeight": 1,
+    "children": [
+     {
+      "name": "t",
+      "type": "TEXT",
+      "text": {
+       "characters": "Case",
+       "fontSize": 12,
+       "fontStyle": "Medium",
+       "style": "badge",
+       "fillVar": "color/feedback/info/foreground"
+      },
+      "fill": {
+       "var": "color/feedback/info/foreground"
+      }
+     }
+    ]
+   },
+   {
+    "name": "Variant=Ghost, State=Default",
+    "type": "COMPONENT",
+    "layout": {
+     "mode": "HORIZONTAL",
+     "primary": "CENTER",
+     "counter": "CENTER",
+     "spacing": 0,
+     "padding": [
+      4,
+      12,
+      4,
+      12
+     ],
+     "primarySizing": "AUTO",
+     "counterSizing": "AUTO"
+    },
+    "cornerRadius": 8,
+    "stroke": {
+     "var": "color/feedback/info/foreground"
+    },
+    "strokeWeight": 1,
+    "children": [
+     {
+      "name": "t",
+      "type": "TEXT",
+      "text": {
+       "characters": "Case",
+       "fontSize": 12,
+       "fontStyle": "Medium",
+       "style": "badge",
+       "fillVar": "color/feedback/info/foreground"
+      },
+      "fill": {
+       "var": "color/feedback/info/foreground"
+      }
+     }
+    ]
+   },
+   {
+    "name": "Variant=Info, State=Hover",
+    "type": "COMPONENT",
+    "layout": {
+     "mode": "HORIZONTAL",
+     "primary": "CENTER",
+     "counter": "CENTER",
+     "spacing": 0,
+     "padding": [
+      4,
+      12,
+      4,
+      12
+     ],
+     "primarySizing": "AUTO",
+     "counterSizing": "AUTO"
+    },
+    "cornerRadius": 8,
+    "fill": {
+     "hex": "dddad7"
+    },
+    "stroke": {
+     "var": "color/feedback/info/foreground"
+    },
+    "strokeWeight": 1,
+    "children": [
+     {
+      "name": "t",
+      "type": "TEXT",
+      "text": {
+       "characters": "Case",
+       "fontSize": 12,
+       "fontStyle": "Medium",
+       "style": "badge",
+       "fillVar": "color/feedback/info/foreground"
+      },
+      "fill": {
+       "var": "color/feedback/info/foreground"
+      }
+     }
+    ]
+   },
+   {
+    "name": "Variant=Ghost, State=Hover",
+    "type": "COMPONENT",
+    "layout": {
+     "mode": "HORIZONTAL",
+     "primary": "CENTER",
+     "counter": "CENTER",
+     "spacing": 0,
+     "padding": [
+      4,
+      12,
+      4,
+      12
+     ],
+     "primarySizing": "AUTO",
+     "counterSizing": "AUTO"
+    },
+    "cornerRadius": 8,
+    "stroke": {
+     "var": "color/feedback/info/foreground"
+    },
+    "strokeWeight": 1,
+    "children": [
+     {
+      "name": "t",
+      "type": "TEXT",
+      "text": {
+       "characters": "Case",
+       "fontSize": 12,
+       "fontStyle": "Medium",
+       "style": "badge",
+       "fillVar": "color/feedback/info/foreground"
+      },
+      "fill": {
+       "var": "color/feedback/info/foreground"
+      }
+     }
+    ]
+   }
+  ]
+ }
+}

--- a/extract/figma/conformance/cases/grid-root-hug-height-fixed-conflict.dump.json
+++ b/extract/figma/conformance/cases/grid-root-hug-height-fixed-conflict.dump.json
@@ -1,0 +1,99 @@
+{
+ "_provenance": {
+  "fileKey": null,
+  "dumpVersion": "1.17",
+  "note": "canvas conformance fixture - hand-authored dump v1.9 (Phase 2 exam)"
+ },
+ "Case": {
+  "setName": "Case",
+  "type": "COMPONENT",
+  "variants": [
+   {
+    "name": "Case",
+    "type": "COMPONENT",
+    "bbox": {
+     "width": 1296,
+     "height": 95
+    },
+    "layout": {
+     "mode": "GRID",
+     "padding": [
+      0,
+      0,
+      0,
+      0
+     ],
+     "primarySizing": "FIXED",
+     "counterSizing": "AUTO",
+     "grid": {
+      "rows": [
+       {
+        "fit": true
+       }
+      ],
+      "columns": [
+       {
+        "fr": 1
+       },
+       {
+        "fr": 1
+       },
+       {
+        "fr": 1
+       }
+      ],
+      "rowGap": 24,
+      "columnGap": 24,
+      "flow": "row"
+     }
+    },
+    "maxWidth": 1296,
+    "fillWidth": true,
+    "children": [
+     {
+      "name": "a",
+      "type": "FRAME",
+      "layout": {
+       "mode": "HORIZONTAL",
+       "primary": "CENTER",
+       "counter": "CENTER",
+       "spacing": 0,
+       "padding": [
+        0,
+        0,
+        0,
+        0
+       ],
+       "primarySizing": "AUTO",
+       "counterSizing": "AUTO"
+      },
+      "fill": {
+       "var": "color/feedback/info/background"
+      },
+      "grid": {
+       "row": 0,
+       "column": 0,
+       "columnSpan": 2
+      },
+      "children": [
+       {
+        "name": "t",
+        "type": "TEXT",
+        "text": {
+         "characters": "Case",
+         "fontSize": 12,
+         "fontStyle": "Medium",
+         "style": "badge",
+         "fillVar": "color/feedback/info/foreground"
+        },
+        "fill": {
+         "var": "color/feedback/info/foreground"
+        }
+       }
+      ]
+     }
+    ]
+   }
+  ]
+ }
+}

--- a/extract/figma/conformance/cases/rest-child-frame-fixed-size.rest.json
+++ b/extract/figma/conformance/cases/rest-child-frame-fixed-size.rest.json
@@ -1,0 +1,158 @@
+{
+ "name": "canvas conformance fixture (REST boundary)",
+ "nodes": {
+  "1:28": {
+   "document": {
+    "id": "1:28",
+    "name": "Case",
+    "type": "COMPONENT",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [
+     {
+      "blendMode": "NORMAL",
+      "type": "SOLID",
+      "color": {
+       "r": 0.9,
+       "g": 0.92,
+       "b": 0.95,
+       "a": 1
+      }
+     }
+    ],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "cornerRadius": 0,
+    "layoutMode": "HORIZONTAL",
+    "primaryAxisAlignItems": "CENTER",
+    "counterAxisAlignItems": "CENTER",
+    "paddingLeft": 12,
+    "paddingRight": 12,
+    "paddingTop": 4,
+    "paddingBottom": 4,
+    "itemSpacing": 0,
+    "layoutWrap": "NO_WRAP",
+    "layoutSizingHorizontal": "HUG",
+    "layoutSizingVertical": "HUG",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 80,
+     "height": 28
+    },
+    "effects": [],
+    "interactions": [],
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "children": [
+     {
+      "id": "1:29",
+      "name": "a",
+      "type": "FRAME",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "clipsContent": true,
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.2,
+         "g": 0.4,
+         "b": 0.8,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "INSIDE",
+      "cornerRadius": 0,
+      "layoutMode": "HORIZONTAL",
+      "primaryAxisAlignItems": "CENTER",
+      "counterAxisAlignItems": "CENTER",
+      "paddingLeft": 0,
+      "paddingRight": 0,
+      "paddingTop": 0,
+      "paddingBottom": 0,
+      "itemSpacing": 0,
+      "layoutWrap": "NO_WRAP",
+      "layoutSizingHorizontal": "FIXED",
+      "layoutSizingVertical": "FIXED",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 20,
+       "height": 20
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "children": []
+     },
+     {
+      "id": "1:30",
+      "name": "t",
+      "type": "TEXT",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "characters": "Case",
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.1,
+         "g": 0.1,
+         "b": 0.1,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "OUTSIDE",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 40,
+       "height": 16
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "style": {
+       "fontFamily": "Inter",
+       "fontPostScriptName": "Inter-Medium",
+       "fontStyle": "Medium",
+       "fontWeight": 500,
+       "fontSize": 12,
+       "textAlignHorizontal": "LEFT",
+       "textAlignVertical": "TOP",
+       "letterSpacing": 0,
+       "lineHeightPx": 16,
+       "lineHeightPercent": 100,
+       "lineHeightUnit": "PIXELS",
+       "textAutoResize": "WIDTH_AND_HEIGHT"
+      }
+     }
+    ]
+   },
+   "components": {},
+   "componentSets": {},
+   "styles": {}
+  }
+ }
+}

--- a/extract/figma/conformance/cases/rest-effect-bound-variables.rest.json
+++ b/extract/figma/conformance/cases/rest-effect-bound-variables.rest.json
@@ -1,0 +1,175 @@
+{
+ "name": "canvas conformance fixture (REST boundary)",
+ "nodes": {
+  "1:12": {
+   "document": {
+    "id": "1:12",
+    "name": "Case",
+    "type": "COMPONENT",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [
+     {
+      "blendMode": "NORMAL",
+      "type": "SOLID",
+      "color": {
+       "r": 0.9,
+       "g": 0.92,
+       "b": 0.95,
+       "a": 1
+      }
+     }
+    ],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "cornerRadius": 0,
+    "layoutMode": "HORIZONTAL",
+    "primaryAxisAlignItems": "CENTER",
+    "counterAxisAlignItems": "CENTER",
+    "paddingLeft": 12,
+    "paddingRight": 12,
+    "paddingTop": 4,
+    "paddingBottom": 4,
+    "itemSpacing": 0,
+    "layoutWrap": "NO_WRAP",
+    "layoutSizingHorizontal": "HUG",
+    "layoutSizingVertical": "HUG",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 64,
+     "height": 24
+    },
+    "effects": [
+     {
+      "type": "DROP_SHADOW",
+      "visible": true,
+      "color": {
+       "r": 0,
+       "g": 0,
+       "b": 0,
+       "a": 0.1
+      },
+      "blendMode": "NORMAL",
+      "offset": {
+       "x": 0,
+       "y": 4
+      },
+      "radius": 8,
+      "spread": 0,
+      "showShadowBehindNode": false,
+      "boundVariables": {
+       "radius": {
+        "type": "VARIABLE_ALIAS",
+        "id": "VariableID:9:1"
+       },
+       "spread": {
+        "type": "VARIABLE_ALIAS",
+        "id": "VariableID:9:2"
+       },
+       "color": {
+        "type": "VARIABLE_ALIAS",
+        "id": "VariableID:9:3"
+       },
+       "offsetX": {
+        "type": "VARIABLE_ALIAS",
+        "id": "VariableID:9:4"
+       },
+       "offsetY": {
+        "type": "VARIABLE_ALIAS",
+        "id": "VariableID:9:5"
+       }
+      }
+     }
+    ],
+    "interactions": [],
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "children": [
+     {
+      "id": "1:13",
+      "name": "t",
+      "type": "TEXT",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "characters": "Case",
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.1,
+         "g": 0.1,
+         "b": 0.1,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "OUTSIDE",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 40,
+       "height": 16
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "style": {
+       "fontFamily": "Inter",
+       "fontPostScriptName": "Inter-Medium",
+       "fontStyle": "Medium",
+       "fontWeight": 500,
+       "fontSize": 12,
+       "textAlignHorizontal": "LEFT",
+       "textAlignVertical": "TOP",
+       "letterSpacing": 0,
+       "lineHeightPx": 16,
+       "lineHeightPercent": 100,
+       "lineHeightUnit": "PIXELS",
+       "textAutoResize": "WIDTH_AND_HEIGHT"
+      }
+     }
+    ],
+    "boundVariables": {
+     "effects": [
+      {
+       "type": "VARIABLE_ALIAS",
+       "id": "VariableID:9:1"
+      },
+      {
+       "type": "VARIABLE_ALIAS",
+       "id": "VariableID:9:2"
+      },
+      {
+       "type": "VARIABLE_ALIAS",
+       "id": "VariableID:9:3"
+      },
+      {
+       "type": "VARIABLE_ALIAS",
+       "id": "VariableID:9:4"
+      },
+      {
+       "type": "VARIABLE_ALIAS",
+       "id": "VariableID:9:5"
+      }
+     ]
+    }
+   },
+   "components": {},
+   "componentSets": {},
+   "styles": {}
+  }
+ }
+}

--- a/extract/figma/conformance/cases/rest-effect-style-identity.rest.json
+++ b/extract/figma/conformance/cases/rest-effect-style-identity.rest.json
@@ -1,0 +1,138 @@
+{
+ "name": "canvas conformance fixture (REST boundary)",
+ "nodes": {
+  "1:10": {
+   "document": {
+    "id": "1:10",
+    "name": "Case",
+    "type": "COMPONENT",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [
+     {
+      "blendMode": "NORMAL",
+      "type": "SOLID",
+      "color": {
+       "r": 0.9,
+       "g": 0.92,
+       "b": 0.95,
+       "a": 1
+      }
+     }
+    ],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "cornerRadius": 0,
+    "layoutMode": "HORIZONTAL",
+    "primaryAxisAlignItems": "CENTER",
+    "counterAxisAlignItems": "CENTER",
+    "paddingLeft": 12,
+    "paddingRight": 12,
+    "paddingTop": 4,
+    "paddingBottom": 4,
+    "itemSpacing": 0,
+    "layoutWrap": "NO_WRAP",
+    "layoutSizingHorizontal": "HUG",
+    "layoutSizingVertical": "HUG",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 64,
+     "height": 24
+    },
+    "effects": [
+     {
+      "type": "DROP_SHADOW",
+      "visible": true,
+      "color": {
+       "r": 0,
+       "g": 0,
+       "b": 0,
+       "a": 0.1
+      },
+      "blendMode": "NORMAL",
+      "offset": {
+       "x": 0,
+       "y": 4
+      },
+      "radius": 8,
+      "spread": 0,
+      "showShadowBehindNode": false
+     }
+    ],
+    "interactions": [],
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "children": [
+     {
+      "id": "1:11",
+      "name": "t",
+      "type": "TEXT",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "characters": "Case",
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.1,
+         "g": 0.1,
+         "b": 0.1,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "OUTSIDE",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 40,
+       "height": 16
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "style": {
+       "fontFamily": "Inter",
+       "fontPostScriptName": "Inter-Medium",
+       "fontStyle": "Medium",
+       "fontWeight": 500,
+       "fontSize": 12,
+       "textAlignHorizontal": "LEFT",
+       "textAlignVertical": "TOP",
+       "letterSpacing": 0,
+       "lineHeightPx": 16,
+       "lineHeightPercent": 100,
+       "lineHeightUnit": "PIXELS",
+       "textAutoResize": "WIDTH_AND_HEIGHT"
+      }
+     }
+    ],
+    "styles": {
+     "effect": "5:1"
+    }
+   },
+   "components": {},
+   "componentSets": {},
+   "styles": {
+    "5:1": {
+     "name": "shadow/md",
+     "styleType": "EFFECT",
+     "key": "effstylekey1"
+    }
+   }
+  }
+ }
+}

--- a/extract/figma/conformance/cases/rest-instance-fill-override.rest.json
+++ b/extract/figma/conformance/cases/rest-instance-fill-override.rest.json
@@ -1,0 +1,195 @@
+{
+ "name": "canvas conformance fixture (REST boundary)",
+ "nodes": {
+  "1:31": {
+   "document": {
+    "id": "1:31",
+    "name": "Case",
+    "type": "COMPONENT",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [
+     {
+      "blendMode": "NORMAL",
+      "type": "SOLID",
+      "color": {
+       "r": 0.9,
+       "g": 0.92,
+       "b": 0.95,
+       "a": 1
+      }
+     }
+    ],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "cornerRadius": 0,
+    "layoutMode": "HORIZONTAL",
+    "primaryAxisAlignItems": "CENTER",
+    "counterAxisAlignItems": "CENTER",
+    "paddingLeft": 12,
+    "paddingRight": 12,
+    "paddingTop": 4,
+    "paddingBottom": 4,
+    "itemSpacing": 0,
+    "layoutWrap": "NO_WRAP",
+    "layoutSizingHorizontal": "HUG",
+    "layoutSizingVertical": "HUG",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 80,
+     "height": 28
+    },
+    "effects": [],
+    "interactions": [],
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "children": [
+     {
+      "id": "1:50",
+      "name": "Icon",
+      "type": "INSTANCE",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "clipsContent": false,
+      "fills": [],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "INSIDE",
+      "cornerRadius": 0,
+      "layoutMode": "HORIZONTAL",
+      "primaryAxisAlignItems": "CENTER",
+      "counterAxisAlignItems": "CENTER",
+      "paddingLeft": 0,
+      "paddingRight": 0,
+      "paddingTop": 0,
+      "paddingBottom": 0,
+      "itemSpacing": 0,
+      "layoutWrap": "NO_WRAP",
+      "layoutSizingHorizontal": "FIXED",
+      "layoutSizingVertical": "FIXED",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 16,
+       "height": 16
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "children": [
+       {
+        "id": "I1:50;8:9",
+        "name": "Vector",
+        "type": "VECTOR",
+        "blendMode": "PASS_THROUGH",
+        "fills": [
+         {
+          "blendMode": "NORMAL",
+          "type": "SOLID",
+          "color": {
+           "r": 1,
+           "g": 1,
+           "b": 1,
+           "a": 1
+          }
+         }
+        ],
+        "strokes": [],
+        "strokeWeight": 1,
+        "strokeAlign": "CENTER",
+        "absoluteBoundingBox": {
+         "x": 0,
+         "y": 0,
+         "width": 16,
+         "height": 16
+        },
+        "constraints": {
+         "vertical": "SCALE",
+         "horizontal": "SCALE"
+        },
+        "effects": [],
+        "interactions": []
+       }
+      ],
+      "componentId": "8:8",
+      "overrides": [
+       {
+        "id": "I1:50;8:9",
+        "overriddenFields": [
+         "fills"
+        ]
+       }
+      ]
+     },
+     {
+      "id": "1:33",
+      "name": "t",
+      "type": "TEXT",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "characters": "Case",
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.1,
+         "g": 0.1,
+         "b": 0.1,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "OUTSIDE",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 40,
+       "height": 16
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "style": {
+       "fontFamily": "Inter",
+       "fontPostScriptName": "Inter-Medium",
+       "fontStyle": "Medium",
+       "fontWeight": 500,
+       "fontSize": 12,
+       "textAlignHorizontal": "LEFT",
+       "textAlignVertical": "TOP",
+       "letterSpacing": 0,
+       "lineHeightPx": 16,
+       "lineHeightPercent": 100,
+       "lineHeightUnit": "PIXELS",
+       "textAutoResize": "WIDTH_AND_HEIGHT"
+      }
+     }
+    ]
+   },
+   "components": {
+    "8:8": {
+     "name": "Glyph",
+     "key": "glyphkey1"
+    }
+   },
+   "componentSets": {},
+   "styles": {}
+  }
+ }
+}

--- a/extract/figma/conformance/cases/rest-instance-slot-prop-value.rest.json
+++ b/extract/figma/conformance/cases/rest-instance-slot-prop-value.rest.json
@@ -1,0 +1,169 @@
+{
+ "name": "canvas conformance fixture (REST boundary)",
+ "nodes": {
+  "1:37": {
+   "document": {
+    "id": "1:37",
+    "name": "Case",
+    "type": "COMPONENT",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [
+     {
+      "blendMode": "NORMAL",
+      "type": "SOLID",
+      "color": {
+       "r": 0.9,
+       "g": 0.92,
+       "b": 0.95,
+       "a": 1
+      }
+     }
+    ],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "cornerRadius": 0,
+    "layoutMode": "HORIZONTAL",
+    "primaryAxisAlignItems": "CENTER",
+    "counterAxisAlignItems": "CENTER",
+    "paddingLeft": 12,
+    "paddingRight": 12,
+    "paddingTop": 4,
+    "paddingBottom": 4,
+    "itemSpacing": 0,
+    "layoutWrap": "NO_WRAP",
+    "layoutSizingHorizontal": "HUG",
+    "layoutSizingVertical": "HUG",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 80,
+     "height": 28
+    },
+    "effects": [],
+    "interactions": [],
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "children": [
+     {
+      "id": "1:38",
+      "name": "Group",
+      "type": "INSTANCE",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "clipsContent": false,
+      "fills": [],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "INSIDE",
+      "cornerRadius": 0,
+      "layoutMode": "HORIZONTAL",
+      "primaryAxisAlignItems": "CENTER",
+      "counterAxisAlignItems": "CENTER",
+      "paddingLeft": 0,
+      "paddingRight": 0,
+      "paddingTop": 0,
+      "paddingBottom": 0,
+      "itemSpacing": 0,
+      "layoutWrap": "NO_WRAP",
+      "layoutSizingHorizontal": "FIXED",
+      "layoutSizingVertical": "FIXED",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 48,
+       "height": 20
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "children": [],
+      "componentId": "8:8",
+      "overrides": [],
+      "componentProperties": {
+       "Items#3:2": {
+        "type": "SLOT",
+        "value": {
+         "guid": {
+          "sessionID": -1,
+          "localID": -1
+         }
+        }
+       },
+       "Alignment": {
+        "type": "VARIANT",
+        "value": "Default"
+       }
+      }
+     },
+     {
+      "id": "1:39",
+      "name": "t",
+      "type": "TEXT",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "characters": "Case",
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.1,
+         "g": 0.1,
+         "b": 0.1,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "OUTSIDE",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 40,
+       "height": 16
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "style": {
+       "fontFamily": "Inter",
+       "fontPostScriptName": "Inter-Medium",
+       "fontStyle": "Medium",
+       "fontWeight": 500,
+       "fontSize": 12,
+       "textAlignHorizontal": "LEFT",
+       "textAlignVertical": "TOP",
+       "letterSpacing": 0,
+       "lineHeightPx": 16,
+       "lineHeightPercent": 100,
+       "lineHeightUnit": "PIXELS",
+       "textAutoResize": "WIDTH_AND_HEIGHT"
+      }
+     }
+    ]
+   },
+   "components": {
+    "8:8": {
+     "name": "Group",
+     "key": "groupkey1"
+    }
+   },
+   "componentSets": {},
+   "styles": {}
+  }
+ }
+}

--- a/extract/figma/conformance/cases/rest-instance-swap-fixed-value.rest.json
+++ b/extract/figma/conformance/cases/rest-instance-swap-fixed-value.rest.json
@@ -1,0 +1,168 @@
+{
+ "name": "canvas conformance fixture (REST boundary)",
+ "nodes": {
+  "1:34": {
+   "document": {
+    "id": "1:34",
+    "name": "Case",
+    "type": "COMPONENT",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [
+     {
+      "blendMode": "NORMAL",
+      "type": "SOLID",
+      "color": {
+       "r": 0.9,
+       "g": 0.92,
+       "b": 0.95,
+       "a": 1
+      }
+     }
+    ],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "cornerRadius": 0,
+    "layoutMode": "HORIZONTAL",
+    "primaryAxisAlignItems": "CENTER",
+    "counterAxisAlignItems": "CENTER",
+    "paddingLeft": 12,
+    "paddingRight": 12,
+    "paddingTop": 4,
+    "paddingBottom": 4,
+    "itemSpacing": 0,
+    "layoutWrap": "NO_WRAP",
+    "layoutSizingHorizontal": "HUG",
+    "layoutSizingVertical": "HUG",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 80,
+     "height": 28
+    },
+    "effects": [],
+    "interactions": [],
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "children": [
+     {
+      "id": "1:35",
+      "name": "Chip",
+      "type": "INSTANCE",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "clipsContent": false,
+      "fills": [],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "INSIDE",
+      "cornerRadius": 0,
+      "layoutMode": "HORIZONTAL",
+      "primaryAxisAlignItems": "CENTER",
+      "counterAxisAlignItems": "CENTER",
+      "paddingLeft": 0,
+      "paddingRight": 0,
+      "paddingTop": 0,
+      "paddingBottom": 0,
+      "itemSpacing": 0,
+      "layoutWrap": "NO_WRAP",
+      "layoutSizingHorizontal": "FIXED",
+      "layoutSizingVertical": "FIXED",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 48,
+       "height": 20
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "children": [],
+      "componentId": "8:8",
+      "overrides": [],
+      "componentProperties": {
+       "Icon#3:1": {
+        "type": "INSTANCE_SWAP",
+        "value": "9:9"
+       },
+       "State": {
+        "type": "VARIANT",
+        "value": "Default"
+       }
+      }
+     },
+     {
+      "id": "1:36",
+      "name": "t",
+      "type": "TEXT",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "characters": "Case",
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.1,
+         "g": 0.1,
+         "b": 0.1,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "OUTSIDE",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 40,
+       "height": 16
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "style": {
+       "fontFamily": "Inter",
+       "fontPostScriptName": "Inter-Medium",
+       "fontStyle": "Medium",
+       "fontWeight": 500,
+       "fontSize": 12,
+       "textAlignHorizontal": "LEFT",
+       "textAlignVertical": "TOP",
+       "letterSpacing": 0,
+       "lineHeightPx": 16,
+       "lineHeightPercent": 100,
+       "lineHeightUnit": "PIXELS",
+       "textAutoResize": "WIDTH_AND_HEIGHT"
+      }
+     }
+    ]
+   },
+   "components": {
+    "8:8": {
+     "name": "Chip",
+     "key": "chipkey1"
+    },
+    "9:9": {
+     "name": "Glyph",
+     "key": "glyphkey1"
+    }
+   },
+   "componentSets": {},
+   "styles": {}
+  }
+ }
+}

--- a/extract/figma/conformance/cases/rest-instance-target-aspect-ratio.rest.json
+++ b/extract/figma/conformance/cases/rest-instance-target-aspect-ratio.rest.json
@@ -1,0 +1,158 @@
+{
+ "name": "canvas conformance fixture (REST boundary)",
+ "nodes": {
+  "1:47": {
+   "document": {
+    "id": "1:47",
+    "name": "Case",
+    "type": "COMPONENT",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [
+     {
+      "blendMode": "NORMAL",
+      "type": "SOLID",
+      "color": {
+       "r": 0.9,
+       "g": 0.92,
+       "b": 0.95,
+       "a": 1
+      }
+     }
+    ],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "cornerRadius": 0,
+    "layoutMode": "HORIZONTAL",
+    "primaryAxisAlignItems": "CENTER",
+    "counterAxisAlignItems": "CENTER",
+    "paddingLeft": 12,
+    "paddingRight": 12,
+    "paddingTop": 4,
+    "paddingBottom": 4,
+    "itemSpacing": 0,
+    "layoutWrap": "NO_WRAP",
+    "layoutSizingHorizontal": "HUG",
+    "layoutSizingVertical": "HUG",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 80,
+     "height": 28
+    },
+    "effects": [],
+    "interactions": [],
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "children": [
+     {
+      "id": "1:48",
+      "name": "Icon",
+      "type": "INSTANCE",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "clipsContent": false,
+      "fills": [],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "INSIDE",
+      "cornerRadius": 0,
+      "layoutMode": "HORIZONTAL",
+      "primaryAxisAlignItems": "CENTER",
+      "counterAxisAlignItems": "CENTER",
+      "paddingLeft": 0,
+      "paddingRight": 0,
+      "paddingTop": 0,
+      "paddingBottom": 0,
+      "itemSpacing": 0,
+      "layoutWrap": "NO_WRAP",
+      "layoutSizingHorizontal": "FIXED",
+      "layoutSizingVertical": "FIXED",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 16,
+       "height": 16
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "children": [],
+      "componentId": "8:8",
+      "overrides": [],
+      "targetAspectRatio": {
+       "x": 16,
+       "y": 16
+      }
+     },
+     {
+      "id": "1:49",
+      "name": "t",
+      "type": "TEXT",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "characters": "Case",
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.1,
+         "g": 0.1,
+         "b": 0.1,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "OUTSIDE",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 40,
+       "height": 16
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "style": {
+       "fontFamily": "Inter",
+       "fontPostScriptName": "Inter-Medium",
+       "fontStyle": "Medium",
+       "fontWeight": 500,
+       "fontSize": 12,
+       "textAlignHorizontal": "LEFT",
+       "textAlignVertical": "TOP",
+       "letterSpacing": 0,
+       "lineHeightPx": 16,
+       "lineHeightPercent": 100,
+       "lineHeightUnit": "PIXELS",
+       "textAutoResize": "WIDTH_AND_HEIGHT"
+      }
+     }
+    ]
+   },
+   "components": {
+    "8:8": {
+     "name": "Glyph",
+     "key": "glyphkey1"
+    }
+   },
+   "componentSets": {},
+   "styles": {}
+  }
+ }
+}

--- a/extract/figma/conformance/cases/rest-item-reverse-z-index.rest.json
+++ b/extract/figma/conformance/cases/rest-item-reverse-z-index.rest.json
@@ -1,0 +1,156 @@
+{
+ "name": "canvas conformance fixture (REST boundary)",
+ "nodes": {
+  "1:44": {
+   "document": {
+    "id": "1:44",
+    "name": "Case",
+    "type": "COMPONENT",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [
+     {
+      "blendMode": "NORMAL",
+      "type": "SOLID",
+      "color": {
+       "r": 0.9,
+       "g": 0.92,
+       "b": 0.95,
+       "a": 1
+      }
+     }
+    ],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "cornerRadius": 0,
+    "layoutMode": "HORIZONTAL",
+    "primaryAxisAlignItems": "CENTER",
+    "counterAxisAlignItems": "CENTER",
+    "paddingLeft": 12,
+    "paddingRight": 12,
+    "paddingTop": 4,
+    "paddingBottom": 4,
+    "itemSpacing": 0,
+    "layoutWrap": "NO_WRAP",
+    "layoutSizingHorizontal": "HUG",
+    "layoutSizingVertical": "HUG",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 80,
+     "height": 28
+    },
+    "effects": [],
+    "interactions": [],
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "children": [
+     {
+      "id": "1:45",
+      "name": "a",
+      "type": "FRAME",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "clipsContent": false,
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.2,
+         "g": 0.4,
+         "b": 0.8,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "INSIDE",
+      "cornerRadius": 0,
+      "layoutMode": "HORIZONTAL",
+      "primaryAxisAlignItems": "CENTER",
+      "counterAxisAlignItems": "CENTER",
+      "paddingLeft": 0,
+      "paddingRight": 0,
+      "paddingTop": 0,
+      "paddingBottom": 0,
+      "itemSpacing": 0,
+      "layoutWrap": "NO_WRAP",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 20,
+       "height": 20
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "children": []
+     },
+     {
+      "id": "1:46",
+      "name": "b",
+      "type": "FRAME",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "clipsContent": false,
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.8,
+         "g": 0.4,
+         "b": 0.2,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "INSIDE",
+      "cornerRadius": 0,
+      "layoutMode": "HORIZONTAL",
+      "primaryAxisAlignItems": "CENTER",
+      "counterAxisAlignItems": "CENTER",
+      "paddingLeft": 0,
+      "paddingRight": 0,
+      "paddingTop": 0,
+      "paddingBottom": 0,
+      "itemSpacing": 0,
+      "layoutWrap": "NO_WRAP",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 20,
+       "height": 20
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "children": []
+     }
+    ],
+    "itemReverseZIndex": true
+   },
+   "components": {},
+   "componentSets": {},
+   "styles": {}
+  }
+ }
+}

--- a/extract/figma/conformance/cases/rest-layout-sizing-vertical-fill.rest.json
+++ b/extract/figma/conformance/cases/rest-layout-sizing-vertical-fill.rest.json
@@ -1,0 +1,160 @@
+{
+ "name": "canvas conformance fixture (REST boundary)",
+ "nodes": {
+  "1:25": {
+   "document": {
+    "id": "1:25",
+    "name": "Case",
+    "type": "COMPONENT",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [
+     {
+      "blendMode": "NORMAL",
+      "type": "SOLID",
+      "color": {
+       "r": 0.9,
+       "g": 0.92,
+       "b": 0.95,
+       "a": 1
+      }
+     }
+    ],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "cornerRadius": 0,
+    "layoutMode": "HORIZONTAL",
+    "primaryAxisAlignItems": "CENTER",
+    "counterAxisAlignItems": "MIN",
+    "paddingLeft": 12,
+    "paddingRight": 12,
+    "paddingTop": 4,
+    "paddingBottom": 4,
+    "itemSpacing": 0,
+    "layoutWrap": "NO_WRAP",
+    "layoutSizingHorizontal": "HUG",
+    "layoutSizingVertical": "FIXED",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 120,
+     "height": 64
+    },
+    "effects": [],
+    "interactions": [],
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "children": [
+     {
+      "id": "1:26",
+      "name": "a",
+      "type": "FRAME",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "clipsContent": false,
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.2,
+         "g": 0.4,
+         "b": 0.8,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "INSIDE",
+      "cornerRadius": 0,
+      "layoutMode": "HORIZONTAL",
+      "primaryAxisAlignItems": "CENTER",
+      "counterAxisAlignItems": "CENTER",
+      "paddingLeft": 0,
+      "paddingRight": 0,
+      "paddingTop": 0,
+      "paddingBottom": 0,
+      "itemSpacing": 0,
+      "layoutWrap": "NO_WRAP",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "FILL",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 40,
+       "height": 56
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "children": [],
+      "layoutAlign": "STRETCH"
+     },
+     {
+      "id": "1:27",
+      "name": "t",
+      "type": "TEXT",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "characters": "Case",
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.1,
+         "g": 0.1,
+         "b": 0.1,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "OUTSIDE",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 40,
+       "height": 16
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "style": {
+       "fontFamily": "Inter",
+       "fontPostScriptName": "Inter-Medium",
+       "fontStyle": "Medium",
+       "fontWeight": 500,
+       "fontSize": 12,
+       "textAlignHorizontal": "LEFT",
+       "textAlignVertical": "TOP",
+       "letterSpacing": 0,
+       "lineHeightPx": 16,
+       "lineHeightPercent": 100,
+       "lineHeightUnit": "PIXELS",
+       "textAutoResize": "WIDTH_AND_HEIGHT"
+      }
+     }
+    ],
+    "counterAxisSizingMode": "FIXED"
+   },
+   "components": {},
+   "componentSets": {},
+   "styles": {}
+  }
+ }
+}

--- a/extract/figma/conformance/cases/rest-prototype-reaction.rest.json
+++ b/extract/figma/conformance/cases/rest-prototype-reaction.rest.json
@@ -1,0 +1,134 @@
+{
+ "name": "canvas conformance fixture (REST boundary)",
+ "nodes": {
+  "1:14": {
+   "document": {
+    "id": "1:14",
+    "name": "Case",
+    "type": "COMPONENT",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [
+     {
+      "blendMode": "NORMAL",
+      "type": "SOLID",
+      "color": {
+       "r": 0.9,
+       "g": 0.92,
+       "b": 0.95,
+       "a": 1
+      }
+     }
+    ],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "cornerRadius": 0,
+    "layoutMode": "HORIZONTAL",
+    "primaryAxisAlignItems": "CENTER",
+    "counterAxisAlignItems": "CENTER",
+    "paddingLeft": 12,
+    "paddingRight": 12,
+    "paddingTop": 4,
+    "paddingBottom": 4,
+    "itemSpacing": 0,
+    "layoutWrap": "NO_WRAP",
+    "layoutSizingHorizontal": "HUG",
+    "layoutSizingVertical": "HUG",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 64,
+     "height": 24
+    },
+    "effects": [],
+    "interactions": [
+     {
+      "trigger": {
+       "type": "ON_HOVER"
+      },
+      "actions": [
+       {
+        "type": "NODE",
+        "destinationId": "1:99",
+        "navigation": "CHANGE_TO",
+        "transition": {
+         "type": "SMART_ANIMATE",
+         "easing": {
+          "type": "LINEAR"
+         },
+         "duration": 0.3
+        },
+        "resetVideoPosition": false
+       }
+      ]
+     }
+    ],
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "children": [
+     {
+      "id": "1:15",
+      "name": "t",
+      "type": "TEXT",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "characters": "Case",
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.1,
+         "g": 0.1,
+         "b": 0.1,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "OUTSIDE",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 40,
+       "height": 16
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "style": {
+       "fontFamily": "Inter",
+       "fontPostScriptName": "Inter-Medium",
+       "fontStyle": "Medium",
+       "fontWeight": 500,
+       "fontSize": 12,
+       "textAlignHorizontal": "LEFT",
+       "textAlignVertical": "TOP",
+       "letterSpacing": 0,
+       "lineHeightPx": 16,
+       "lineHeightPercent": 100,
+       "lineHeightUnit": "PIXELS",
+       "textAutoResize": "WIDTH_AND_HEIGHT"
+      }
+     }
+    ],
+    "transitionNodeID": "1:99",
+    "transitionDuration": 300,
+    "transitionEasing": "LINEAR"
+   },
+   "components": {},
+   "componentSets": {},
+   "styles": {}
+  }
+ }
+}

--- a/extract/figma/conformance/cases/rest-slot-property-definition.rest.json
+++ b/extract/figma/conformance/cases/rest-slot-property-definition.rest.json
@@ -1,0 +1,247 @@
+{
+ "name": "canvas conformance fixture (REST boundary)",
+ "nodes": {
+  "1:16": {
+   "document": {
+    "id": "1:16",
+    "name": "Case",
+    "type": "COMPONENT_SET",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 120,
+     "height": 80
+    },
+    "effects": [],
+    "interactions": [],
+    "layoutSizingHorizontal": "FIXED",
+    "layoutSizingVertical": "FIXED",
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "componentPropertyDefinitions": {
+     "Media#7:1": {
+      "type": "SLOT",
+      "defaultValue": {
+       "guid": {
+        "sessionID": -1,
+        "localID": -1
+       }
+      },
+      "preferredValues": [
+       {
+        "type": "COMPONENT_SET",
+        "key": "de1d1f4d9674a79e188e32cf71ea15dafc2355bf"
+       }
+      ]
+     },
+     "Variant": {
+      "type": "VARIANT",
+      "defaultValue": "Default",
+      "variantOptions": [
+       "Default"
+      ]
+     }
+    },
+    "children": [
+     {
+      "id": "1:17",
+      "name": "Variant=Default",
+      "type": "COMPONENT",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "clipsContent": false,
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.9,
+         "g": 0.92,
+         "b": 0.95,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "INSIDE",
+      "cornerRadius": 0,
+      "layoutMode": "VERTICAL",
+      "primaryAxisAlignItems": "CENTER",
+      "counterAxisAlignItems": "CENTER",
+      "paddingLeft": 12,
+      "paddingRight": 12,
+      "paddingTop": 4,
+      "paddingBottom": 4,
+      "itemSpacing": 0,
+      "layoutWrap": "NO_WRAP",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 120,
+       "height": 80
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "children": [
+       {
+        "id": "1:18",
+        "name": "s",
+        "type": "SLOT",
+        "scrollBehavior": "SCROLLS",
+        "blendMode": "PASS_THROUGH",
+        "clipsContent": false,
+        "fills": [],
+        "strokes": [],
+        "strokeWeight": 1,
+        "strokeAlign": "INSIDE",
+        "cornerRadius": 0,
+        "layoutMode": "HORIZONTAL",
+        "primaryAxisAlignItems": "CENTER",
+        "counterAxisAlignItems": "CENTER",
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+        "paddingBottom": 0,
+        "itemSpacing": 0,
+        "layoutWrap": "NO_WRAP",
+        "layoutSizingHorizontal": "FILL",
+        "layoutSizingVertical": "HUG",
+        "absoluteBoundingBox": {
+         "x": 0,
+         "y": 0,
+         "width": 96,
+         "height": 48
+        },
+        "effects": [],
+        "interactions": [],
+        "constraints": {
+         "vertical": "TOP",
+         "horizontal": "LEFT"
+        },
+        "children": [
+         {
+          "id": "1:19",
+          "name": "Glyph",
+          "type": "INSTANCE",
+          "scrollBehavior": "SCROLLS",
+          "blendMode": "PASS_THROUGH",
+          "clipsContent": false,
+          "fills": [],
+          "strokes": [],
+          "strokeWeight": 1,
+          "strokeAlign": "INSIDE",
+          "cornerRadius": 0,
+          "layoutMode": "HORIZONTAL",
+          "primaryAxisAlignItems": "CENTER",
+          "counterAxisAlignItems": "CENTER",
+          "paddingLeft": 0,
+          "paddingRight": 0,
+          "paddingTop": 0,
+          "paddingBottom": 0,
+          "itemSpacing": 0,
+          "layoutWrap": "NO_WRAP",
+          "layoutSizingHorizontal": "FIXED",
+          "layoutSizingVertical": "FIXED",
+          "absoluteBoundingBox": {
+           "x": 0,
+           "y": 0,
+           "width": 24,
+           "height": 24
+          },
+          "effects": [],
+          "interactions": [],
+          "constraints": {
+           "vertical": "TOP",
+           "horizontal": "LEFT"
+          },
+          "children": [],
+          "componentId": "8:8",
+          "overrides": []
+         }
+        ],
+        "componentPropertyReferences": {
+         "slotContentId": "Media#7:1"
+        }
+       },
+       {
+        "id": "1:20",
+        "name": "t",
+        "type": "TEXT",
+        "scrollBehavior": "SCROLLS",
+        "blendMode": "PASS_THROUGH",
+        "characters": "Case",
+        "fills": [
+         {
+          "blendMode": "NORMAL",
+          "type": "SOLID",
+          "color": {
+           "r": 0.1,
+           "g": 0.1,
+           "b": 0.1,
+           "a": 1
+          }
+         }
+        ],
+        "strokes": [],
+        "strokeWeight": 1,
+        "strokeAlign": "OUTSIDE",
+        "layoutSizingHorizontal": "HUG",
+        "layoutSizingVertical": "HUG",
+        "absoluteBoundingBox": {
+         "x": 0,
+         "y": 0,
+         "width": 40,
+         "height": 16
+        },
+        "effects": [],
+        "interactions": [],
+        "constraints": {
+         "vertical": "TOP",
+         "horizontal": "LEFT"
+        },
+        "style": {
+         "fontFamily": "Inter",
+         "fontPostScriptName": "Inter-Medium",
+         "fontStyle": "Medium",
+         "fontWeight": 500,
+         "fontSize": 12,
+         "textAlignHorizontal": "LEFT",
+         "textAlignVertical": "TOP",
+         "letterSpacing": 0,
+         "lineHeightPx": 16,
+         "lineHeightPercent": 100,
+         "lineHeightUnit": "PIXELS",
+         "textAutoResize": "WIDTH_AND_HEIGHT"
+        }
+       }
+      ]
+     }
+    ]
+   },
+   "components": {
+    "8:8": {
+     "name": "Glyph",
+     "key": "glyphkey1"
+    }
+   },
+   "componentSets": {},
+   "styles": {}
+  }
+ }
+}

--- a/extract/figma/conformance/cases/rest-swap-preferred-values-empty.rest.json
+++ b/extract/figma/conformance/cases/rest-swap-preferred-values-empty.rest.json
@@ -1,0 +1,199 @@
+{
+ "name": "canvas conformance fixture (REST boundary)",
+ "nodes": {
+  "1:21": {
+   "document": {
+    "id": "1:21",
+    "name": "Case",
+    "type": "COMPONENT_SET",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 120,
+     "height": 32
+    },
+    "effects": [],
+    "interactions": [],
+    "layoutSizingHorizontal": "FIXED",
+    "layoutSizingVertical": "FIXED",
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "componentPropertyDefinitions": {
+     "Icon#7:2": {
+      "type": "INSTANCE_SWAP",
+      "defaultValue": "8:8",
+      "preferredValues": []
+     },
+     "Variant": {
+      "type": "VARIANT",
+      "defaultValue": "Default",
+      "variantOptions": [
+       "Default"
+      ]
+     }
+    },
+    "children": [
+     {
+      "id": "1:22",
+      "name": "Variant=Default",
+      "type": "COMPONENT",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "clipsContent": false,
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.9,
+         "g": 0.92,
+         "b": 0.95,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "INSIDE",
+      "cornerRadius": 0,
+      "layoutMode": "HORIZONTAL",
+      "primaryAxisAlignItems": "CENTER",
+      "counterAxisAlignItems": "CENTER",
+      "paddingLeft": 12,
+      "paddingRight": 12,
+      "paddingTop": 4,
+      "paddingBottom": 4,
+      "itemSpacing": 0,
+      "layoutWrap": "NO_WRAP",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 120,
+       "height": 32
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "children": [
+       {
+        "id": "1:23",
+        "name": "Icon",
+        "type": "INSTANCE",
+        "scrollBehavior": "SCROLLS",
+        "blendMode": "PASS_THROUGH",
+        "clipsContent": false,
+        "fills": [],
+        "strokes": [],
+        "strokeWeight": 1,
+        "strokeAlign": "INSIDE",
+        "cornerRadius": 0,
+        "layoutMode": "HORIZONTAL",
+        "primaryAxisAlignItems": "CENTER",
+        "counterAxisAlignItems": "CENTER",
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 0,
+        "paddingBottom": 0,
+        "itemSpacing": 0,
+        "layoutWrap": "NO_WRAP",
+        "layoutSizingHorizontal": "FIXED",
+        "layoutSizingVertical": "FIXED",
+        "absoluteBoundingBox": {
+         "x": 0,
+         "y": 0,
+         "width": 16,
+         "height": 16
+        },
+        "effects": [],
+        "interactions": [],
+        "constraints": {
+         "vertical": "TOP",
+         "horizontal": "LEFT"
+        },
+        "children": [],
+        "componentId": "8:8",
+        "overrides": [],
+        "componentPropertyReferences": {
+         "mainComponent": "Icon#7:2"
+        }
+       },
+       {
+        "id": "1:24",
+        "name": "t",
+        "type": "TEXT",
+        "scrollBehavior": "SCROLLS",
+        "blendMode": "PASS_THROUGH",
+        "characters": "Case",
+        "fills": [
+         {
+          "blendMode": "NORMAL",
+          "type": "SOLID",
+          "color": {
+           "r": 0.1,
+           "g": 0.1,
+           "b": 0.1,
+           "a": 1
+          }
+         }
+        ],
+        "strokes": [],
+        "strokeWeight": 1,
+        "strokeAlign": "OUTSIDE",
+        "layoutSizingHorizontal": "HUG",
+        "layoutSizingVertical": "HUG",
+        "absoluteBoundingBox": {
+         "x": 0,
+         "y": 0,
+         "width": 40,
+         "height": 16
+        },
+        "effects": [],
+        "interactions": [],
+        "constraints": {
+         "vertical": "TOP",
+         "horizontal": "LEFT"
+        },
+        "style": {
+         "fontFamily": "Inter",
+         "fontPostScriptName": "Inter-Medium",
+         "fontStyle": "Medium",
+         "fontWeight": 500,
+         "fontSize": 12,
+         "textAlignHorizontal": "LEFT",
+         "textAlignVertical": "TOP",
+         "letterSpacing": 0,
+         "lineHeightPx": 16,
+         "lineHeightPercent": 100,
+         "lineHeightUnit": "PIXELS",
+         "textAutoResize": "WIDTH_AND_HEIGHT"
+        }
+       }
+      ]
+     }
+    ]
+   },
+   "components": {
+    "8:8": {
+     "name": "Glyph",
+     "key": "glyphkey1"
+    }
+   },
+   "componentSets": {},
+   "styles": {}
+  }
+ }
+}

--- a/extract/figma/conformance/cases/rest-text-align-center.rest.json
+++ b/extract/figma/conformance/cases/rest-text-align-center.rest.json
@@ -1,0 +1,110 @@
+{
+ "name": "canvas conformance fixture (REST boundary)",
+ "nodes": {
+  "1:42": {
+   "document": {
+    "id": "1:42",
+    "name": "Case",
+    "type": "COMPONENT",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [
+     {
+      "blendMode": "NORMAL",
+      "type": "SOLID",
+      "color": {
+       "r": 0.9,
+       "g": 0.92,
+       "b": 0.95,
+       "a": 1
+      }
+     }
+    ],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "cornerRadius": 0,
+    "layoutMode": "HORIZONTAL",
+    "primaryAxisAlignItems": "CENTER",
+    "counterAxisAlignItems": "CENTER",
+    "paddingLeft": 12,
+    "paddingRight": 12,
+    "paddingTop": 4,
+    "paddingBottom": 4,
+    "itemSpacing": 0,
+    "layoutWrap": "NO_WRAP",
+    "layoutSizingHorizontal": "HUG",
+    "layoutSizingVertical": "HUG",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 120,
+     "height": 28
+    },
+    "effects": [],
+    "interactions": [],
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "children": [
+     {
+      "id": "1:43",
+      "name": "t",
+      "type": "TEXT",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "characters": "Case",
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.1,
+         "g": 0.1,
+         "b": 0.1,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "OUTSIDE",
+      "layoutSizingHorizontal": "FIXED",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 96,
+       "height": 16
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "style": {
+       "fontFamily": "Inter",
+       "fontPostScriptName": "Inter-Medium",
+       "fontStyle": "Medium",
+       "fontWeight": 500,
+       "fontSize": 12,
+       "textAlignHorizontal": "CENTER",
+       "textAlignVertical": "TOP",
+       "letterSpacing": 0,
+       "lineHeightPx": 16,
+       "lineHeightPercent": 100,
+       "lineHeightUnit": "PIXELS",
+       "textAutoResize": "HEIGHT"
+      }
+     }
+    ]
+   },
+   "components": {},
+   "componentSets": {},
+   "styles": {}
+  }
+ }
+}

--- a/extract/figma/conformance/cases/rest-text-font-family.rest.json
+++ b/extract/figma/conformance/cases/rest-text-font-family.rest.json
@@ -1,0 +1,110 @@
+{
+ "name": "canvas conformance fixture (REST boundary)",
+ "nodes": {
+  "1:40": {
+   "document": {
+    "id": "1:40",
+    "name": "Case",
+    "type": "COMPONENT",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [
+     {
+      "blendMode": "NORMAL",
+      "type": "SOLID",
+      "color": {
+       "r": 0.9,
+       "g": 0.92,
+       "b": 0.95,
+       "a": 1
+      }
+     }
+    ],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "cornerRadius": 0,
+    "layoutMode": "HORIZONTAL",
+    "primaryAxisAlignItems": "CENTER",
+    "counterAxisAlignItems": "CENTER",
+    "paddingLeft": 12,
+    "paddingRight": 12,
+    "paddingTop": 4,
+    "paddingBottom": 4,
+    "itemSpacing": 0,
+    "layoutWrap": "NO_WRAP",
+    "layoutSizingHorizontal": "HUG",
+    "layoutSizingVertical": "HUG",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 80,
+     "height": 28
+    },
+    "effects": [],
+    "interactions": [],
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "children": [
+     {
+      "id": "1:41",
+      "name": "t",
+      "type": "TEXT",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "characters": "Case",
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.1,
+         "g": 0.1,
+         "b": 0.1,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "OUTSIDE",
+      "layoutSizingHorizontal": "HUG",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 40,
+       "height": 16
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "style": {
+       "fontFamily": "Manrope",
+       "fontPostScriptName": "Manrope-Bold",
+       "fontStyle": "Bold",
+       "fontWeight": 700,
+       "fontSize": 12,
+       "textAlignHorizontal": "LEFT",
+       "textAlignVertical": "TOP",
+       "letterSpacing": 0,
+       "lineHeightPx": 16,
+       "lineHeightPercent": 100,
+       "lineHeightUnit": "PIXELS",
+       "textAutoResize": "WIDTH_AND_HEIGHT"
+      }
+     }
+    ]
+   },
+   "components": {},
+   "componentSets": {},
+   "styles": {}
+  }
+ }
+}

--- a/extract/figma/conformance/cases/slot-frame-child-default-content.dump.json
+++ b/extract/figma/conformance/cases/slot-frame-child-default-content.dump.json
@@ -1,0 +1,106 @@
+{
+ "_provenance": {
+  "fileKey": null,
+  "dumpVersion": "1.9",
+  "note": "canvas conformance fixture - hand-authored dump v1.9 (Phase 2 exam)"
+ },
+ "Case": {
+  "setName": "Case",
+  "type": "COMPONENT",
+  "variants": [
+   {
+    "name": "Case",
+    "type": "COMPONENT",
+    "layout": {
+     "mode": "VERTICAL",
+     "primary": "MIN",
+     "counter": "MIN",
+     "spacing": 8,
+     "padding": [
+      4,
+      12,
+      4,
+      12
+     ],
+     "primarySizing": "AUTO",
+     "counterSizing": "AUTO"
+    },
+    "fill": {
+     "var": "color/surface/background"
+    },
+    "children": [
+     {
+      "name": "s",
+      "type": "SLOT",
+      "layout": {
+       "mode": "VERTICAL",
+       "primary": "MIN",
+       "counter": "MIN",
+       "spacing": 4,
+       "padding": [
+        0,
+        0,
+        0,
+        0
+       ],
+       "primarySizing": "AUTO",
+       "counterSizing": "AUTO"
+      },
+      "propRefs": {
+       "slotContentId": "Content"
+      },
+      "children": [
+       {
+        "name": "a",
+        "type": "FRAME",
+        "layout": {
+         "mode": "HORIZONTAL",
+         "primary": "CENTER",
+         "counter": "CENTER",
+         "spacing": 4,
+         "padding": [
+          0,
+          0,
+          0,
+          0
+         ],
+         "primarySizing": "AUTO",
+         "counterSizing": "AUTO"
+        },
+        "children": [
+         {
+          "name": "Chip",
+          "type": "INSTANCE",
+          "instanceOf": "Chip",
+          "instanceKey": "chipkey1",
+          "bbox": {
+           "width": 48,
+           "height": 20
+          },
+          "fill": {
+           "hex": "dddddd"
+          }
+         },
+         {
+          "name": "t",
+          "type": "TEXT",
+          "text": {
+           "characters": "Case",
+           "fontSize": 12,
+           "fontStyle": "Medium",
+           "style": "badge",
+           "fillVar": "color/feedback/info/foreground"
+          },
+          "fill": {
+           "var": "color/feedback/info/foreground"
+          }
+         }
+        ]
+       }
+      ]
+     }
+    ]
+   }
+  ]
+ }
+}

--- a/extract/figma/conformance/run.ts
+++ b/extract/figma/conformance/run.ts
@@ -60,7 +60,7 @@
  * capturing them with dump.plugin.js, so the CAPTURE stage is measured too)
  * is named future work — see README.md alongside this file.
  */
-import { readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -70,6 +70,7 @@ import {
 import { loadTokenCorpus } from "../tokens.js";
 import { loadContracts } from "../propose.js";
 import type { DumpDegradation, DumpFile } from "../types.js";
+import { mapRestToDump, type RestNodesResponse } from "../rest/map.js";
 
 // ---------------------------------------------------------------------------
 // Manifest shapes (hand-authored — see MANIFEST.json)
@@ -128,8 +129,30 @@ interface CaseRun {
   namingUnion: string[];
 }
 
-function runCase(dumpPath: string, deps: ReturnType<typeof loadDeps>): CaseRun {
-  const dump = JSON.parse(readFileSync(dumpPath, "utf8")) as DumpFile;
+/** A case may enter at EITHER boundary: `<id>.dump.json` (the plugin dump,
+ *  dump v1 grammar) or `<id>.rest.json` (a GET /v1/files/:key/nodes
+ *  response, mapped through the REAL extract/figma/rest/map.ts — the
+ *  Journey A CLI's own transport). REST cases measure the mapper too: its
+ *  MapReport degradations/notes join the naming union exactly as the CLI
+ *  prints them to stderr, so a fact the mapper drops without a receipt is
+ *  a SILENT loss here, not an absence (Phase 2 exam, 2026-08-22). */
+function caseFileFor(id: string): string {
+  const rest = path.join(CASES_DIR, `${id}.rest.json`);
+  return existsSync(rest) ? rest : path.join(CASES_DIR, `${id}.dump.json`);
+}
+
+function runCase(casePath: string, deps: ReturnType<typeof loadDeps>): CaseRun {
+  const restReceipts: string[] = [];
+  const dump = ((): DumpFile => {
+    const json = JSON.parse(readFileSync(casePath, "utf8")) as unknown;
+    if (!casePath.endsWith(".rest.json")) return json as DumpFile;
+    const { dump: mapped, report } = mapRestToDump(json as RestNodesResponse, { fileKey: null });
+    for (const n of report.notes) restReceipts.push(`rest note: ${n}`);
+    for (const d of report.degradations) {
+      restReceipts.push(`degradation ${d.code} @ ${d.nodePath}${d.field ? ` ${d.field}` : ""}: ${d.message}`);
+    }
+    return mapped as unknown as DumpFile;
+  })();
   const batch = proposeBatchFromDump(
     dump as unknown as Record<string, unknown>,
     {
@@ -167,6 +190,7 @@ function runCase(dumpPath: string, deps: ReturnType<typeof loadDeps>): CaseRun {
   for (const d of (dump._degradations ?? []) as DumpDegradation[]) {
     union.push(`degradation ${d.code} @ ${d.nodePath}: ${d.message}`);
   }
+  union.push(...restReceipts);
   return { contractText: JSON.stringify(contractPieces), namingUnion: union };
 }
 
@@ -240,15 +264,15 @@ function main() {
     );
     process.exit(2);
   }
-  const caseFiles = readdirSync(CASES_DIR).filter((f) =>
-    f.endsWith(".dump.json"),
+  const caseFiles = readdirSync(CASES_DIR).filter(
+    (f) => f.endsWith(".dump.json") || f.endsWith(".rest.json"),
   );
-  const fileIds = new Set(caseFiles.map((f) => f.replace(/\.dump\.json$/, "")));
+  const fileIds = new Set(caseFiles.map((f) => f.replace(/\.(dump|rest)\.json$/, "")));
 
   const deps = loadDeps();
 
   if (probe !== undefined) {
-    const run = runCase(path.join(CASES_DIR, `${probe}.dump.json`), deps);
+    const run = runCase(caseFileFor(probe), deps);
     console.log("--- naming union ---");
     for (const n of run.namingUnion) console.log("  " + n);
     console.log("--- contract text ---");
@@ -283,7 +307,7 @@ function main() {
         expect: c.expect,
         pin: c.status,
         verdict: "MISSING",
-        detail: "manifest entry has no cases/<id>.dump.json",
+        detail: "manifest entry has no cases/<id>.dump.json or cases/<id>.rest.json",
       });
   }
 
@@ -292,7 +316,7 @@ function main() {
     if (!fileIds.has(c.id)) continue;
     let run: CaseRun;
     try {
-      run = runCase(path.join(CASES_DIR, `${c.id}.dump.json`), deps);
+      run = runCase(caseFileFor(c.id), deps);
     } catch (e) {
       rows.push({
         id: c.id,

--- a/parity/receipts/phase-2/FIGMA-DS-EXAM.md
+++ b/parity/receipts/phase-2/FIGMA-DS-EXAM.md
@@ -1,0 +1,198 @@
+# Phase 2 exam — the hand-built "Figma Design System" kit, canvas → code, held out
+
+Date 2026-08-22 · tree `ec74da7b` (origin/main, Phase 1 merged) in a detached worktree · file `aekVseUceg35tVn62knRrj` · read-only against Figma (REST GET + one Console-MCP variables read) · nothing in the engine was developed against this kit (ZERO `ds_contracts` stamps).
+
+Pass condition: SILENT = 0. **Result: SILENT ≠ 0.** Across the 15 component sets, 3,556 canvas facts were read off the REST node documents: **1,502 carried · 1,759 named · 295 silent** (76 of the 295 are render-inert at the drawn size; 219 are not). 8 further rows are named with a wrong reason; 25 rows are named but should have carried (the Button's and the Badge's background). Every silent construct is now a pinned red case in `extract/figma/conformance/` (19 cases, gate GREEN with 19 RED-EXPECTED) — nothing in the engine was fixed.
+
+Artifacts (scratch, not in the patch; the exam worktree's `out/` directory): `out/figma-ds.dump.json`, `out/rest-cli.log`, `out/proposed/` (80 proposals, `figma-proposals.md`, `minted.dtcg.json`), `out/proposed/generated/` (76 components + `tokens.css`), `out/figma-png/`, `out/react-png/`, `out/side-by-side/`, `out/accounting.json`, `out/probes/`.
+
+## 1. REST dump — `npx tsx extract/figma/rest/cli.ts <url> --out out/figma-ds.dump.json`
+
+```
+✔ 77 set(s) [...] → out/figma-ds.dump.json            (15 COMPONENT_SETs + 62 single COMPONENTs; 332,960 bytes; dump v1.5)
+note: variables response not provided — every bound fact degrades to its resolved literal
+1748 degraded lines on stderr:  1595 variable-unresolved · 94 vector-geometry-unsupported · 36 stroke-style-unsupported
+                                 · 14 text-channel-unsupported · 6 stroke-weights-nonuniform · 3 rotation-unsupported
+_provenance.captureGaps: 8 (multi-mode values, absolute placement, image fills, fixed rectangle sizes, instance text
+                          overrides, strokeAlign, layout wrap, constraints)
+```
+
+Facts about the instrument, not the kit:
+
+- **`GET /v1/files/:key/variables/local` → 403 `Invalid scope(s) … This endpoint requires the file_variables:read scope`.** User-fixable (tick one scope on the PAT). `fetch.ts` classifies exactly this (`classifyVariablesRefusal`) but **`cli.ts` never passes `onVariablesUnavailable`**, so the CLI prints the generic `unresolvable — variables endpoint unavailable (Enterprise) or not provided` 1,595 times and the one-checkbox fix is never shown. Named, wrong reason. Consequence: every one of the kit's ~1,600 variable bindings on these 15 sets degrades to a resolved literal; the proposals mint `imported.*` tokens from literals and none of the kit's 1,025 variable names survives.
+- **The 1,748 receipts live only on stderr.** The dump file carries no `_degradations` (REST route) — `propose.ts` cannot see them and `figma-proposals.md` does not repeat them (e.g. the Card Content slot's per-side bottom stroke is named once, on a terminal, and nowhere downstream).
+- Exact-mode refusal for an unstamped kit, verbatim (all 15 sets): `Set "Button" could not be proposed: Exact proposal requires structured propertyDefinitions and variantProperties evidence.` Plus one crash-class refusal: `Card Grid … did not fit the contract schema — field "anatomy.root.parts.Section.component.props.sectionFooter": … Unrecognized key: "guid"` (a nested instance's SLOT-typed property value copied as a prop value).
+
+## 2. Propose — `npx tsx extract/figma/propose.ts out/figma-ds.dump.json --out out/proposed --tokens out/kit.dtcg.json --contracts out/empty-contracts --reviewable-inversion`
+
+The kit has no DTCG twin (its variables were refused above), so the corpus is an empty file and the contracts dir is empty — the foreign-kit shape. Without `--tokens` the CLI warns, correctly, that the repo's demo tokens would bind "wrong by construction".
+
+```
+77 sets proposed (+1 stub ds.button-icon-default-sm), 0 skipped; figma-proposals.md 1,468 lines; minted.dtcg.json 50,249 bytes
+- no captured variables: the dump carries no `_variables` channel (REST transport …) — recapture with the plugin (dump v1.4+)
+captured.dtcg.json: NOT WRITTEN (the receipt above is the only trace of the 1,025 variables / 11 collections / 6-mode Appearance)
+Button 53 notes, 1 unbound · Badge 40 notes, 1 unbound · Card 30 notes, 2 unbound · Toast 49 notes, 0 unbound
+```
+
+## 3. Generate, type-check, render
+
+`npx ds-contracts generate <80 files> --out out/proposed/generated --stories --tokens out/kit.dtcg.json,out/proposed/minted.dtcg.json` (the printed next step):
+
+```
+✖ Contract validation failed:
+  - ds.section-header: part "root" carries channel "height" as BOTH a token binding and a literal — ambiguous, refused by name
+  - ds.section-footer: … (same)                                   → exit 1, NOTHING generated for any of the 80
+minus those two:  ✘ Refused — ds.section: slot "children" defaultContent references unknown contract "ds.section-header"
+minus section + card-grid as well:  76 components generated, tokens.css beside them (exit 0)
+```
+
+The double spelling is the proposer's: a GRID root whose single row is `{fit}` (REST `layoutSizingVertical: HUG`) is mapped `primarySizing: FIXED` with a bbox, so propose emits `literals.height: fit-content` (G8) **and** `tokens.height: {imported.section-header.root.height} = 95px`. Named by the emitter, but one set's contradiction blocks the whole batch. Case: `grid-root-hug-height-fixed-conflict`.
+
+Type-check (`tsc --noEmit`, strict, react-jsx, `*.css` declared): **1 error** — `Card.tsx(10,18) TS2430: Interface 'CardProps' incorrectly extends interface 'HTMLAttributes<HTMLDivElement>'` — the Card's second slot is named `content`, which collides with the HTML `content` attribute (string). Generated code does not compile as-is.
+
+Render (esbuild bundle of the generated components + Playwright, deviceScaleFactor 2, white ground) vs Figma's own `/v1/images?scale=2` of the same cells — `out/side-by-side/<cell>.png` (Figma left, React right):
+
+| cell | Figma node | verdict | what is off |
+|---|---|---|---|
+| `button-primary-default` | 53:2776 | **NOT recognisable** | React has no fill: white label on white inside a 1px grey rounded border. The root `fill` is `UNBOUND … no token invented` ("fill differs in state hover but is absent in some variants — a state override cannot unset a channel; NAMED, not proposed"). Figma: solid #8f8781 pill, white text. |
+| `badge-sm-success` | 91:4929 | recognisable | an 8×8 green dot on both sides (ELLIPSE decor + opacity 0.8 carried). |
+| `badge-default-success` | 91:4941 | same shape, missing fill | both sides are "Badge" struck through by a green line — the kit binds line-height to a variable whose value is **1.5 (PIXELS)**, so Figma itself collapses the pill to ~2px; the React side additionally has no background (`UNBOUND Badge:root fill = #b7e9c5`). The proposal's default is `size=sm` (first variant); the set's declared default is `Size=Default`. |
+| `card-default` | 53:1778 | **NOT recognisable** | Figma: light-grey card, image placeholder with glyph, kicker/heading/dek (overlapping — the same 1.5px line height), a Chip, an arrow button. React: a near-transparent box (`#00000001`, the REST-resolved fill under a GLASS effect) holding one grey square. The Content slot's drawn content (Title frame → Kicker+Heading, Footer frame → Chip+Button Group) vanished — only the bare `Dek` instance survived as `defaultContent`, and the Default story does not even pass it. Vector glyphs are named unsupported. |
+| `toast-default` | 86:2196 | recognisable as a toast | same grey bar, 1px border, drop shadow, 600×48, title/body (overlapping on both sides — kit line height). React has no icon glyph and no close glyph (vector geometry named unsupported; the nested Button (Icon)'s fixed `Icon` swap value is dropped silently). |
+
+PNGs: `out/side-by-side/{button-primary-default,badge-sm-success,badge-default-success,card-default,toast-default}.png`; sources `out/figma-png/*.png`, `out/react-png/*.png`.
+
+## 4. Accounting — the four sampled sets
+
+Denominator: every fact on the REST node documents of the set (variants walked; instance internals counted once as the instance; set-container node excluded). Classification verified against `map.ts`, `figma-proposals.md` and the proposed contract. Full rows: `out/accounting.json`; script `out/account.mjs`.
+
+| set | carried | named | silent | of which render-inert | wrong-name | named-but-should-carry |
+|---|---|---|---|---|---|---|
+| Button | 426 | 549 | 109 | 65 (50 targetAspectRatio, 15 itemReverseZIndex) | 0 | 20 (root fill, every variant) |
+| Badge | 88 | 96 | 6 | 0 | 0 | 5 (root fill, Size=Default) |
+| Card | 34 | 34 | 10 | 0 | 2 | 0 |
+| Toast | 127 | 156 | 30 | 5 | 1 | 0 |
+
+Per-channel (carried / named / silent) — `out/four-set-table.md` has the full table; the rows that are not all-carried:
+
+**Button** (axes Variant×State, props Text/Slot Before/Slot After/Icon Before/Icon After): State axis → NAMED (promoted to hover/focus-visible/disabled; Active "renders identically" — true, REST Default≡Active) · boundVariables 515 NAMED (stderr) + 5 SILENT · fills 25 carried-as-value / 20 NAMED-UNBOUND (channel dropped) · swap accepts 2 NAMED (keys with no in-scope contract) · strokeAlign OUTSIDE 6 NAMED · Focus Outline ABSOLUTE 5 NAMED → inverted to `outline-*` (carried) · minHeight (bound 884:4650) 25 carried · opacity 0.5 bound (Disabled) carried · **SILENT:** `interactions` ON_HOVER→CHANGE_TO (2: `Button:Variant=Primary, State=Default`, `Variant=Danger, State=Default`; `transitionNodeID`/`transitionDuration`/`transitionEasing`) · `styles.effect` 53:3846 on the 5 Hover roots · `boundVariables.effects` (5 roots × radius/spread/color/offsetX/offsetY → VariableID:1112:1561…1565) · `overrides[].fills` on every Icon Before/Icon After instance (32; the icon colour per variant) · `itemReverseZIndex` (15, inert) · `targetAspectRatio` 16:16 on 50 icon instances (inert at fixed size).
+
+**Badge** (Size×Variant, Text): Size=sm rows 8×8 Dot (ELLIPSE, opacity .8) carried · Size=Default rows fill NAMED-UNBOUND → no background · border-color carried per cell with the "SATURATED pair" note · **SILENT:** `propertyDefinitions.Size.defaultValue = "Default"` vs proposed default `sm` · `style.textAlignHorizontal = CENTER` on the 5 Text nodes.
+
+**Card** (Variant Default|Inline, SLOT props Image/Content): SLOT nodes carried as slot parts; SLOT property definitions (REST `defaultValue: {guid}`, Image `preferredValues: [{COMPONENT_SET de1d1f4d…}]`) dropped by `map.ts` (typeof string check) and then **named with the wrong reason** ("REST returns componentPropertyDefinitions EMPTY for SLOT properties") · effects `[DROP_SHADOW, GLASS, BACKGROUND_BLUR]` NAMED not proposed · minWidth/maxWidth 416 (Default only) NAMED + UNBOUND · clipsContent NAMED · per-side bottom stroke on `Container/Content` (individualStrokeWeights 0/0/1/0) NAMED on stderr only, stroke absent from the dump · Inline `layoutByProp` carried · **SILENT:** `styles.effect` 55:9749 (2) · `boundVariables.effects` (2; DROP_SHADOW radius/spread/color/offsets + BACKGROUND_BLUR radius) · SLOT child FRAMEs `Content/Title` (Kicker+Heading) and `Content/Footer` (Chip+Button Group) in both variants (4) · `Inline/Container/Image` `layoutSizingVertical: FILL` (1) · `Inline/Container/Image` FIXED width 308 on a SLOT (1).
+
+**Toast** (Variant, INSTANCE_SWAP Icon): width FIXED 600 (size.x bound 53:310) minted · minHeight 48 (bound) minted · DROP_SHADOW → box-shadow · `Content` grow carried · nested Button (Icon) `State` NAMED ("does not map through ds.button-icon's bindings") · Icon `preferredValues: []` named as "not captured in dump v1" (**wrong reason**: REST returned an empty list) · **SILENT:** `styles.effect` 53:3846 (5) · `boundVariables.effects` (5) · `overrides[].fills` on Icon/Icon (10) · `componentProperties.Icon#21315:0 = 53:3841` (INSTANCE_SWAP fixed value) on the nested Button (Icon) (5) · `targetAspectRatio` 20:20 (5, inert).
+
+### All 15 sets — counts
+
+| set | carried | named | silent (inert) | wrong-name | should-carry |
+|---|---|---|---|---|---|
+| Badge | 88 | 96 | 6 (0) | 0 | 5 |
+| Button | 426 | 549 | 109 (65) | 0 | 20 |
+| Button (Icon) | 31 | 43 | 8 (5) | 0 | 0 |
+| Button (contract) | 225 | 290 | 60 (0) | 0 | 0 |
+| Chip | 153 | 194 | 15 (0) | 1 | 0 |
+| Dek | 19 | 14 | 0 | 0 | 0 |
+| Heading | 296 | 294 | 44 (0) | 0 | 0 |
+| Image | 9 | 9 | 0 | 0 | 0 |
+| Kicker | 17 | 16 | 4 (0) | 0 | 0 |
+| Button Group | 15 | 7 | 0 | 1 | 0 |
+| Section Header | 27 | 30 | 4 (1) | 0 | 0 |
+| Section Footer | 16 | 14 | 2 (0) | 0 | 0 |
+| Toast | 127 | 156 | 30 (5) | 1 | 0 |
+| Card | 34 | 34 | 10 (0) | 2 | 0 |
+| Section | 19 | 13 | 3 (0) | 3 | 0 |
+| **total** | **1,502** | **1,759** | **295 (76)** | **8** | **25** |
+
+SILENT constructs across the 15 (set · channel · rows · first path):
+
+```
+Badge            axis default (Size: Default, first variant sm)                1   set.propertyDefinitions.Size.defaultValue
+Badge            text textAlignHorizontal=CENTER                               5   Badge:Size=Default, Variant=Success/Text
+Button           itemReverseZIndex (inert)                                    15   Button:Variant=Primary, State=Default
+Button           interactions ON_HOVER→CHANGE_TO (+transitionNodeID)           2   Button:Variant=Primary, State=Default
+Button           overrides[].fills (host override of icon vector fill)        32   Button:Variant=Primary, State=Default/Icon Before
+Button           targetAspectRatio 16:16 (inert)                              50   Button:Variant=Primary, State=Default/Icon Before
+Button           boundVariables.effects                                        5   Button:Variant=Primary, State=Hover
+Button           styles.effect 53:3846                                         5   Button:Variant=Primary, State=Hover
+Button (Icon)    targetAspectRatio (inert) 5 · boundVariables.effects 1 · styles.effect 1 · overrides[].fills 1
+Button (contract) layoutSizingHorizontal=FIXED child FRAME 20px               30   Button (contract):…/slot-before, slot-after, icon
+Button (contract) layoutSizingVertical=FIXED child FRAME 20px                 30   (same nodes)
+Chip             axis default (Dismissible: True, first variant False)          1   set.propertyDefinitions.Dismissible.defaultValue
+Chip             componentProperties.Icon#21315:6 INSTANCE_SWAP fixed value   10   Chip:State=Default, Dismissible=False/Button (Icon)
+Chip             boundVariables.effects 2 · styles.effect 2                         Chip:State=Hover, Dismissible=False
+Heading          axis default (Tag: h1 vs h6; Variant: xxl vs xs)               2   set.propertyDefinitions.{Tag,Variant}.defaultValue
+Heading          text fontFamily Manrope                                      42   Heading:Tag=h6, Variant=xs/Text
+Kicker           text fontFamily Manrope 2 · textAlignHorizontal=CENTER 2          Kicker:Size=Default/Kicker
+Section Header   componentProperties.Items#5624:28 SLOT value {guid}           2   Section Header:Alignment=Default/Container/Button Group
+Section Header   itemReverseZIndex 1 (inert) · overrides[].fills 1
+Section Footer   textAlignHorizontal=CENTER 1 · Items#5624:28 SLOT value 1
+Toast            boundVariables.effects 5 · styles.effect 5 · overrides[].fills 10 · targetAspectRatio 5 (inert)
+Toast            componentProperties.Icon#21315:0 INSTANCE_SWAP fixed value    5   Toast:Variant=Default/Button (Icon)
+Card             boundVariables.effects 2 · styles.effect 2
+Card             SLOT child FRAME as design-time content                        4   Card:Variant=Default/Container/Content/Title (+Footer)
+Card             layoutSizingVertical=FILL 1 · FIXED SLOT width 308px 1            Card:Variant=Inline/Container/Image
+Section          SLOT child FRAME as design-time content                        3   Section:Layout=Default/Container/Section Content/Stacked
+```
+
+Wrong-name rows (8): the 6 SLOT property definitions (Card Image/Content, Button Group Items, Section Header/Content/Footer) named as "REST returns componentPropertyDefinitions EMPTY" when REST returned them; the 2 empty INSTANCE_SWAP preferredValues (Chip Icon, Toast Icon) named "not captured in dump v1" when the list is empty by design.
+
+Named-but-should-carry (25): Button root fill (20 variants; Ghost has none → `UNBOUND`, hover differs → "cannot unset") and Badge root fill (5 Size=Default variants; Size=sm has none → `UNBOUND`). The stroke path already mints `#00000000` for absent variants ("a strokeless node is a zero-width transparent stroke"); the fill path does not, and the component loses its background.
+
+Not counted as facts (inert REST bookkeeping, listed so nobody asks): `complexStrokeProperties: {strokeType: BASIC}` (306), `scrollBehavior`, `absoluteRenderBounds`, `background`/`backgroundColor` (legacy duplicates of `fills`), `exportSettings` (3), `constraints` on vectors (named by captureGap), `layoutAlign/layoutGrow` (duplicates of layoutSizing*). `cornerSmoothing` is 0 everywhere; `lineTypes`, `characterStyleOverrides`, `textTruncation` are empty/disabled everywhere.
+
+## 5. Modes
+
+Ground truth (read-only Console-MCP `figma_get_variables`, Desktop bridge, 2026-08-22): **1,025 variables in 11 collections** (the brief says 1,072/12 — the canvas today has 1,025/11; STRING 109 · FLOAT 623 · COLOR 287 · BOOLEAN 6):
+
+```
+Tier 1 | Primitive 368 vars, 1 mode (Default)         Tier 2 | Semantic 154, 1 mode          Tier 3 | Typography 138, 1 mode
+Tier 1 | Theme 190, 3 modes (Default, Southleft, Brutalist)
+Tier 2 | Color Scheme 51, 3 modes (Light, Dark, Accent)          Tier 2 | Shape 14, 3 (Default, Pill, Sharp)
+Tier 2 | Motion 3, 3 (Default, Expressive, Reduced)               Tier 2 | Density 26, 3 (Default, Compact, Comfortable)
+Tier 2 | Text Size 20, 3 (Default, Small, Large)                  Tier 2 | Depth 36, 3 (Default, Flat, Deep)
+Tier 3 | Appearance 25, 6 modes (Default, Outlined, Surface, Elevated, Glass, Gradient)
+```
+
+What `captured.dtcg.json` carries per mode: **nothing — the file was not written.** The CLI receipt: `no captured variables: the dump carries no _variables channel (REST transport or a pre-v1.4 plugin dump) — the designer's variables are not in this folder; recapture with the plugin (dump v1.4+) to carry them`, and per set the read-limit note `multi-mode variable values (dump v1.6 modes): not captured on this route — only one mode's resolved values are readable, so a theme/mode axis resolves single-mode and the other modes' values are absent`. What it does not say: that the route *could* have named every binding (the REST variables endpoint answers with `file_variables:read`), that the resolved literals are the **Default** mode of each collection (Light / Default appearance / Default theme) with no mode recorded anywhere, and that Southleft/Brutalist/Dark/Accent/Pill/Sharp/Compact/Comfortable/Small/Large/Flat/Deep/Outlined/Surface/Elevated/Glass/Gradient are not merely "absent" but indistinguishable from never having existed. `minted.dtcg.json` (50 KB) is single-mode literals under `imported.*`.
+
+## 6. Conformance cases authored (before any fix) — `extract/figma/conformance/`
+
+`conformance/cases/` is the CSS/DOM fixture (every case needs `Case.tsx` + `case.css`; its canvas direction is declared via `dumpSnippet` and measured by `extract/figma/conformance`). The canvas-side constructs above have no CSS spelling to mount, so the cases live in the canvas-side twin, `extract/figma/conformance/` (manifest-driven, one construct each, `MANIFEST.json` is the denominator). Fourteen of the silences are in `extract/figma/rest/map.ts`, which the dump grammar cannot reach, so the runner gained one thing: a case may enter at the REST boundary as `cases/<id>.rest.json` (a `/v1/files/:key/nodes` response) and is mapped through the real `mapRestToDump`, its MapReport joining the naming union exactly as the CLI prints it. Expectations were written from the documentation model before the engine ran; observed behaviour is pinned in `observedCheck`.
+
+| case | boundary | expect | observed (pinned) |
+|---|---|---|---|
+| rest-effect-style-identity | REST | LEDGERED | SILENT |
+| rest-effect-bound-variables | REST | LEDGERED | SILENT |
+| rest-prototype-reaction | REST | LEDGERED | SILENT |
+| rest-slot-property-definition | REST | LEDGERED | WRONG-NAME ("REST returns … EMPTY") |
+| rest-swap-preferred-values-empty | REST | LEDGERED | WRONG-NAME ("not captured in dump v1") |
+| rest-layout-sizing-vertical-fill | REST | CARRIED (`align: stretch`) | SILENT |
+| rest-child-frame-fixed-size | REST | CARRIED | SILENT |
+| rest-instance-fill-override | REST | LEDGERED | SILENT |
+| rest-instance-swap-fixed-value | REST | LEDGERED | SILENT |
+| rest-instance-slot-prop-value | REST | LEDGERED | whole-set schema refusal |
+| rest-text-font-family | REST | LEDGERED | SILENT |
+| rest-text-align-center | REST | CARRIED | SILENT |
+| rest-item-reverse-z-index | REST | LEDGERED | SILENT (inert) |
+| rest-instance-target-aspect-ratio | REST | LEDGERED | SILENT (inert) |
+| axis-default-from-set | dump | CARRIED | SILENT (first variant wins) |
+| fill-absent-on-axis-value | dump | CARRIED | named UNBOUND, channel dropped |
+| fill-unset-by-state | dump | CARRIED | named "cannot unset", channel dropped |
+| slot-frame-child-default-content | dump | LEDGERED | SILENT |
+| grid-root-hug-height-fixed-conflict | dump | CARRIED (one spelling) | double spelling → emitter refusal |
+
+`npx tsx extract/figma/conformance/run.ts` → `135 case(s): 116 PASS, 19 RED-EXPECTED (pinned findings), 0 FAIL, 0 UNEXPECTED-GREEN, 0 UNLISTED, 0 MISSING — CANVAS CONFORMANCE: GREEN` (baseline before the cases: 116/116 PASS).
+
+Not fixtured (no manifest can exercise HTTP): `cli.ts` dropping `classifyVariablesRefusal`'s user-fixable diagnosis; the stderr-only transport of the 1,748 map receipts.
+
+## 7. Defects, in the order a designer would hit them
+
+1. Button and Badge render with **no background** — the root fill is refused ("UNBOUND", "cannot unset") when one variant lacks a fill; the stroke path has the transparent-for-absent rule, the fill path does not. (`fill-absent-on-axis-value`, `fill-unset-by-state`)
+2. Card content is **gone** — a SLOT's drawn content survives only when it is a bare INSTANCE; FRAME children (Title, Footer) vanish silently. (`slot-frame-child-default-content`)
+3. `generate` refuses the **whole batch** because a GRID root with a fit row is spelled both `height: fit-content` and `height: {token}`. (`grid-root-hug-height-fixed-conflict`)
+4. A nested instance's SLOT-typed prop value crashes exact mode (Card Grid) and is dropped in reviewable mode. (`rest-instance-slot-prop-value`)
+5. The kit's 1,025 variables are unnameable on this route because the PAT lacks one scope — and the CLI calls it "Enterprise".
+6. Effect styles, effect variable bindings, prototype reactions, icon-colour overrides, fixed swap values on nested instances, vertical FILL, fixed child-frame sizes, non-Inter families, text-align, declared axis defaults: silent (14 cases).
+7. Generated `Card.tsx` does not type-check (slot named `content`).
+8. `lineHeight: 1.5 (PIXELS)` — the kit binds line height to a variable valued 1.5; Figma renders it as 1.5px too (text overlaps on both sides). Faithful, not a defect of the engine; worth telling the kit's author.


### PR DESCRIPTION
The held-out canvas→code exam from the plan. Receipt: `parity/receipts/phase-2/FIGMA-DS-EXAM.md`. Verdict SILENT ≠ 0 (295 of 3,556 facts); Button/Card not recognisable; four Journey-A CLI honesty defects. Nineteen manifest-driven canvas conformance cases are RED-EXPECTED (gate green by name) — the fix round targets them one by one. No engine change in this PR.