### PR TITLE
A native slot's interior auto-layout is carried — canvas conformance 154/154

### DIFF
--- a/accuracy/grammar.json
+++ b/accuracy/grammar.json
@@ -45,9 +45,9 @@
     {
       "id": "canvas",
       "path": "extract/figma/conformance/MANIFEST.json",
-      "count": 152,
+      "count": 154,
       "expectations": {
-        "CARRIED": 105,
+        "CARRIED": 107,
         "LEDGERED": 38,
         "REFUSED": 9
       }

--- a/core/exact-proposal-check.ts
+++ b/core/exact-proposal-check.ts
@@ -3767,7 +3767,7 @@ console.log(
 }
 
 console.log(
-  "\n49. PRIMARY-axis FILL on a native SLOT — a SLOT child that FILLS along its ROW parent's primary axis in every variant carries `layout.grow` exactly like a FRAME child (canvas conformance slot-primary-axis-fill + rest-slot-primary-axis-fill)",
+  "\n49. PRIMARY-axis FILL on a native SLOT — a SLOT child that FILLS along its ROW parent's primary axis in every variant carries `layout.grow` exactly like a FRAME child, inside the SAME layout block its interior auto-layout rides since r11 (canvas conformance slot-primary-axis-fill + rest-slot-primary-axis-fill)",
 );
 {
   // r9 found it, r10 fixes it: the Phase 2 exam's Card:Variant=Default/Image
@@ -3840,9 +3840,15 @@ console.log(
         '"slot":{"name":"children"',
       ),
   );
+  // r11: the slot's interior auto-layout (a VERTICAL / CENTER / CENTER slot
+  // with no drawn children — a container by definition) rides the same
+  // layout block as the grow, through invertLayout — the FULL object is
+  // pinned so the next move on this branch shows up here (§50 holds the
+  // interior facts on their own).
   check(
-    "the grow is the whole layout block — the slot's interior auto-layout is not inverted on this branch (a separate fact) and no FIXED receipt fires for a FILL axis",
-    JSON.stringify(layoutOf(uniform, "Image")) === '{"grow":true}' &&
+    "the layout block is the slot's interior auto-layout PLUS the grow (r11: invertLayout on the SLOT branch, one implementation) and no FIXED receipt fires for a FILL axis",
+    JSON.stringify(layoutOf(uniform, "Image")) ===
+      '{"direction":"column","justify":"center","align":"center","grow":true}' &&
       !uniform.notes.some((n) =>
         /P2SlotGrow:root\/Image: .*FC-GEOMETRY-EXCLUDED/.test(n),
       ),
@@ -3876,8 +3882,9 @@ console.log(
     reviewable,
   );
   check(
-    "FILL in 1/2 occurrences is NOT grow (the every-occurrence rule) and the per-variant FIXED receipt still names the FILL side",
-    layoutOf(split, "Image") === undefined &&
+    "FILL in 1/2 occurrences is NOT grow (the every-occurrence rule; the interior layout still carries) and the per-variant FIXED receipt still names the FILL side",
+    JSON.stringify(layoutOf(split, "Image")) ===
+      '{"direction":"column","justify":"center","align":"center"}' &&
       split.notes.some((n) =>
         /P2SlotGrowSplit:root\/Image: auto-layout SLOT child drawn FIXED on width \(FIXED in 1\/2 variant occurrence\(s\) — FIXED on Variant=Inline; FILL on Variant=Default/.test(
           n,
@@ -3898,8 +3905,9 @@ console.log(
     reviewable,
   );
   check(
-    "FILL-width under a COLUMN parent is the cross-axis stretch, not grow — no layout.grow, named by carryCrossAxisFill",
-    layoutOf(column, "Image") === undefined &&
+    "FILL-width under a COLUMN parent is the cross-axis stretch, not grow — no layout.grow (the interior layout still carries), named by carryCrossAxisFill",
+    JSON.stringify(layoutOf(column, "Image")) ===
+      '{"direction":"column","justify":"center","align":"center"}' &&
       column.notes.some((n) =>
         /P2SlotCross:root\/Image: drawn FILL-width under a COLUMN parent whose other children do not all fill/.test(
           n,
@@ -3978,6 +3986,143 @@ console.log(
           e.prop === "variant" &&
           e.map.inline?.height === "100%" &&
           e.map.default?.height === undefined,
+      ),
+  );
+}
+
+console.log(
+  "\n50. The native SLOT's INTERIOR auto-layout — direction / justify / align ride `layout`, gap and padding ride the token channels, a per-variant difference rides layoutByProp: the same doors every FRAME part walks (canvas conformance slot-interior-auto-layout + rest-slot-interior-auto-layout; docs/23 §B.24 → §D.31)",
+);
+{
+  // r11: the Phase 2 exam's Card Content slot — a padded COLUMN with item
+  // spacing and no drawn children — used to come back as a bare flex item
+  // (§49 pinned `{"grow":true}` as the WHOLE block; docs/23 §B.24). The SLOT
+  // branch of buildPart now walks invertNodeTokens + invertLayout +
+  // invertLayoutByProp exactly as the FRAME branch does.
+  const content = (extra: Partial<DumpNode>): DumpNode => ({
+    name: "Content",
+    type: "SLOT",
+    clipsContent: true,
+    layout: {
+      mode: "VERTICAL",
+      primary: "CENTER",
+      counter: "MAX",
+      spacing: 8,
+      padding: [12, 16, 12, 16],
+      primarySizing: "AUTO",
+      counterSizing: "AUTO",
+    },
+    children: [],
+    ...extra,
+  });
+  const variant = (name: string, c: DumpNode): DumpNode => ({
+    name,
+    type: "COMPONENT",
+    bbox: { width: 928, height: 96 },
+    layout: {
+      mode: "HORIZONTAL",
+      primary: "MIN",
+      counter: "MIN",
+      spacing: 24,
+      padding: [0, 0, 0, 0],
+      primarySizing: "FIXED",
+      counterSizing: "AUTO",
+    },
+    fill: { hex: "f0eeed" },
+    children: [c, label()],
+  });
+  const axis = {
+    propertyDefinitions: {
+      Variant: {
+        type: "VARIANT" as const,
+        defaultValue: "Default",
+        variantOptions: ["Default", "Inline"],
+      },
+    },
+  };
+  const uniform = proposeFromDump(
+    p2Set(
+      "P2SlotInterior",
+      [
+        variant("Variant=Default", content({ fillWidth: true })),
+        variant("Variant=Inline", content({ fillWidth: true })),
+      ],
+      axis,
+    ),
+    reviewable,
+  );
+  const part = partOf(uniform, "Content");
+  const tokens = (part?.tokens ?? {}) as Record<string, string>;
+  check(
+    "a SLOT drawn VERTICAL / CENTER / MAX with no drawn children carries layout {direction: column, justify: center, align: end} beside the r10 grow — a slot is a container by definition, so the empty child list does not gate justify/align",
+    JSON.stringify(part?.layout) ===
+      '{"direction":"column","justify":"center","align":"end","grow":true}' &&
+      JSON.stringify(part?.slot ?? {}).includes('"name":"children"'),
+  );
+  check(
+    "its itemSpacing and padding mint on the slot part's token channels (gap / padding-inline / padding-block) exactly as a FRAME part's do, each a named provisional mint",
+    tokens.gap === "{imported.p2-slot-interior.content.gap}" &&
+      tokens["padding-inline"] ===
+        "{imported.p2-slot-interior.content.padding-inline}" &&
+      tokens["padding-block"] ===
+        "{imported.p2-slot-interior.content.padding-block}" &&
+      mintedPaths(uniform).some((ref) => ref === tokens.gap) &&
+      uniform.notes.some((n) =>
+        /MINTED \{imported\.p2-slot-interior\.content\.gap\} = 8px/.test(n),
+      ) &&
+      uniform.notes.some((n) =>
+        /MINTED \{imported\.p2-slot-interior\.content\.padding-inline\} = 16px/.test(
+          n,
+        ),
+      ) &&
+      uniform.notes.some((n) =>
+        /MINTED \{imported\.p2-slot-interior\.content\.padding-block\} = 12px/.test(
+          n,
+        ),
+      ),
+  );
+  // A per-variant interior difference (the Inline variant lays its content
+  // out as a ROW) is a pure function of the `variant` axis → layoutByProp,
+  // the v7 carrier the FRAME branch already uses.
+  const split = proposeFromDump(
+    p2Set(
+      "P2SlotInteriorSplit",
+      [
+        variant("Variant=Default", content({ fillWidth: true })),
+        variant(
+          "Variant=Inline",
+          content({
+            fillWidth: true,
+            layout: {
+              mode: "HORIZONTAL",
+              primary: "MIN",
+              counter: "MIN",
+              spacing: 8,
+              padding: [12, 16, 12, 16],
+              primarySizing: "AUTO",
+              counterSizing: "AUTO",
+            },
+          }),
+        ),
+      ],
+      axis,
+    ),
+    reviewable,
+  );
+  const splitPart = partOf(split, "Content");
+  const lbp = splitPart?.layoutByProp as
+    { prop: string; map: Record<string, Record<string, string>> } | undefined;
+  check(
+    "a per-variant interior difference on the SLOT rides layoutByProp on the axis (Inline → row/start/start over the Default column base), named like a FRAME part's",
+    JSON.stringify(splitPart?.layout) ===
+      '{"direction":"column","justify":"center","align":"end","grow":true}' &&
+      lbp?.prop === "variant" &&
+      JSON.stringify(lbp.map) ===
+        '{"inline":{"direction":"row","justify":"start","align":"start"}}' &&
+      split.notes.some((n) =>
+        /P2SlotInteriorSplit:root\/Content: auto-layout differs across variants as a function of axis "Variant"/.test(
+          n,
+        ),
       ),
   );
 }

--- a/core/propose-figma.ts
+++ b/core/propose-figma.ts
@@ -2386,7 +2386,10 @@ function invertNodeTokens(
     // the FIRST variant's child count let a set whose default variant has a
     // single child (Badge base Icon=False) drop every other variant's
     // itemSpacing with no receipt (untitled-ui round 2, style-channel-dropped).
-    m.occ.some((o) => (o.node.children?.length ?? 0) > 1) &&
+    // r11: a native SLOT's itemSpacing is a rendered fact the moment the
+    // consumer drops two children in — the drawn child count is not the
+    // denominator there (canvas conformance slot-interior-auto-layout).
+    (m.type === 'SLOT' || m.occ.some((o) => (o.node.children?.length ?? 0) > 1)) &&
     m.occ.some((o) => (o.node.layout?.spacing ?? 0) !== 0)
   ) {
     const spacings = m.occ.map((o) => o.node.layout?.spacing ?? 0);
@@ -5501,7 +5504,11 @@ function invertLayout(
     return gridOut;
   }
 
-  const hasChildren = m.children.length > 0;
+  // r11: a native SLOT is a container BY DEFINITION — its children are the
+  // consumer's, so its interior justify/align are facts even when no
+  // design-time content is drawn (the exam's empty Card Content slot). Read
+  // through the node class, not the drawn child count.
+  const hasChildren = m.children.length > 0 || m.type === 'SLOT';
   // P21 overlap collections (AvatarGroup shape): negative itemSpacing in
   // EVERY variant means the children OVERLAP — the existing `layout.overlap`
   // vocabulary, whose shipped projection (ds.avatar-group owner-precedent:
@@ -7245,27 +7252,43 @@ function buildPart(
       );
     }
     part.slot = nativeSlot;
-    // r10 (canvas conformance slot-primary-axis-fill + rest-slot-primary-
-    // axis-fill): the PRIMARY-axis half of the slot's FILL is `layout.grow`
-    // — the rule every FRAME child inverts through, read from the SAME
-    // implementation (primaryAxisGrow), never a second copy. This branch
-    // never computed it, so the Card:Variant=Default Image's FILL-width under
-    // its FIXED-width ROW reached neither the contract nor a note; the FRAME
-    // branch carries grow first and the cross-axis doors below assume it
-    // (crossAxisFillByProp's receipt says "`layout.grow` carries the ROW
-    // plane(s)" — on this branch that sentence used to be untrue). The
-    // slot's own interior auto-layout (direction/justify/align) is NOT
-    // inverted here — a separate, still-unnamed fact.
-    const grow = primaryAxisGrow(m, parentMode);
-    if (grow) part.layout = { grow };
+    // r11 (canvas conformance slot-interior-auto-layout + rest-slot-
+    // interior-auto-layout; docs/23 §B.24 → §D.31): a SLOT node IS a frame with
+    // auto-layout, and its interior layout is the layout the consumer's
+    // content renders in. It inverts through the SAME doors every FRAME and
+    // swap-convention slot-wrapper part walks — invertNodeTokens (gap /
+    // padding and the box channels, minted or bound), invertLayout
+    // (direction / justify / align / wrap, with r10's primary-axis `grow`
+    // computed inside it by primaryAxisGrow — one rule, one implementation)
+    // and invertLayoutByProp (the per-variant split) — never a second copy
+    // of any rule. Until r11 this branch computed the grow alone and
+    // returned, so the exam's Card Content slot (a padded COLUMN with item
+    // spacing) reached neither the contract nor a note. A slot with no
+    // drawn children is still a container (its children are the consumer's):
+    // invertLayout's justify/align and the gap mint read that through
+    // m.type, not the drawn child count.
+    const slotByProp: ByPropCollector = { map: {} };
+    const slotDeclared: Record<string, string> = {};
+    const slotTokens = invertNodeTokens(m, false, ctx, where, slotByProp, part, slotDeclared);
+    if (Object.keys(slotDeclared).length > 0) {
+      part.declared = { ...(part.declared as Record<string, string> | undefined), ...slotDeclared };
+    }
+    attachByProp(part, slotByProp);
+    const slotLayout = invertLayout(m, false, parentMode, ctx, where);
+    if (slotLayout) part.layout = slotLayout;
+    applyLayoutSplit(part, invertLayoutByProp(m, ctx, where));
     // dump v1.31 — a native SLOT's cross-axis FILL had NO door on this branch
     // (the FRAME branch walks both; this one returned first), so the Card
     // Inline Image's FILL-height under its ROW-variant Container was silent
     // (canvas conformance layout-fill-height-parent-mode-by-variant). Same
-    // two doors, same order as the FRAME branch.
+    // two doors, same order as the FRAME branch (r9); the grow they assume
+    // is carried by invertLayout above (r10).
     crossAxisFillByProp(m, parentMode, part, ctx, where);
     carryCrossAxisFill(m, parentMode, part, ctx, where);
+    invertNodeOpacity(m, part, slotTokens, ctx, where);
+    invertNodeEffects(m, slotTokens, ctx, where);
     nameFixedChildGeometry(m, ctx, where); // FC-GEOMETRY-EXCLUDED receipt (Phase 2 exam: Card Inline Image SLOT 308px)
+    attachTokens(ctx, part, slotTokens);
     // Same visibility conventions as every other slot path: the "Show X"
     // convention marks the part optional; any other BOOLEAN visibility
     // binding is a real boolean prop driving the part.

--- a/docs/23-known-limitations.md
+++ b/docs/23-known-limitations.md
@@ -1055,37 +1055,20 @@ used to land as the STRING `[object Object]` are refused by name at bundle
 and plan time, and a Dark mode is added only when the bundle carries one
 (the Starter-plan `addMode` refusal is named, not swallowed).
 
-## B.24 The exam SLOT's interior auto-layout is not inverted
+## B.24 The exam SLOT's interior auto-layout is not inverted — CLOSED, moved
 
-*The two silences this section held until 2026-08-23 — the Card Inline
-Image SLOT's FIXED 308px width (skipped whenever any occurrence filled) and
-its `fillHeight` under mixed parent modes — are CLOSED; they moved to
-[§D.29](#d29-the-held-out-kits-last-two-silences-and-the-slots-primary-axis-fill--closed)
-with their gates. The same round (r10) carried the primary-axis FILL on a
-native SLOT as `layout.grow`. What is left on that node was never silent
-and is not carried either.*
-
-A native SLOT child that FILLS along its ROW parent's primary axis in every
-variant now carries `layout.grow: true` (conformance cases
-`slot-primary-axis-fill` / `rest-slot-primary-axis-fill`, CARRIED). That
-grow is the **whole** layout block the slot part receives: the native-SLOT
-branch of `buildPart` (`core/propose-figma.ts`) reads the primary-axis fill
-through `primaryAxisGrow` — the one implementation the FRAME branch also
-reads — but does not walk `invertLayout`, so the slot's own auto-layout
-(direction, padding, item spacing, justify/align, its own sizing modes) is
-not inverted onto the part. `exact-proposal:check` §49 pins exactly this
-shape: the Image slot's `layout` is `{"grow":true}` and nothing else, and
-no `FC-GEOMETRY-EXCLUDED` receipt fires for a FILL axis.
-
-**What you'd observe** — a slot drawn as a padded COLUMN with item spacing
-comes back as a bare flex item: its size along the parent's row is right,
-its interior is whatever the consumer drops in. No note says so.
-
-**What it would take — an engine change** (route the native-SLOT branch
-through `invertLayout` with the slot's drawn children excluded, so the
-slot's own frame facts carry like any FRAME part's — or name them). Not
-pinned red in the canvas fixture, because no exam set lost a fact to it;
-it is named here so the grow cannot be read as "the slot's layout carries".
+*Closed 2026-08-23 (r11) — moved to
+[§D.31](#d31-the-exam-slots-interior-auto-layout--closed) with its gates.
+The two silences this section held before that (the Card Inline Image SLOT's
+FIXED 308px width and its `fillHeight` under mixed parent modes) closed in
+[§D.29](#d29-the-held-out-kits-last-two-silences-and-the-slots-primary-axis-fill--closed).
+The native-SLOT branch of `buildPart` now walks `invertNodeTokens`,
+`invertLayout` and `invertLayoutByProp` like every FRAME part, so a slot
+drawn as a padded COLUMN with item spacing carries `layout.direction /
+justify / align` and minted `gap` / `padding-*` on the slot part beside the
+r10 `grow`; `exact-proposal:check` §49 pins the full layout object and §50
+the interior facts; conformance cases `slot-interior-auto-layout` and
+`rest-slot-interior-auto-layout` are CARRIED.*
 
 ## B.25 The REST route cannot name a variable binding without `file_variables:read`
 
@@ -1132,7 +1115,8 @@ off, all of it named and none of it carried:
   FRAME child has no carrier and is NAMED`, so the Default story passes no
   content;
 - the two silences that were §B.24 — CLOSED 2026-08-23 (§D.29); the slot's own
-  auto-layout is still not inverted (§B.24).
+  auto-layout — CLOSED 2026-08-23 (§D.31): the Content slot's padded column
+  and its gap now carry on the slot part.
 
 **What you'd observe** — a near-white box holding one grey square where the
 designer drew a card.
@@ -1522,7 +1506,7 @@ on your canvas. The counts are the honest way to see both halves at once.
 |---|---|---|---|
 | CSS / DOM frontier | 82 | CARRIED 42 · LOWERED 4 · REFUSED 18 · UNSUPPORTED 18 (79 pass · 3 red) | `conformance/MANIFEST.json` (`npm run conformance`, 2026-08-23) |
 | canvas round trip of the CARRIED/LOWERED cases | 46 | ROUND-TRIPPED 26 · NAMED 5 · REFUSED-BY-NAME 15 · **SILENT 0** | `conformance/CANVAS-EXPECTATIONS.md` (`npm run conformance:roundtrip`) |
-| canvas constructs | 152 | CARRIED 105 · LEDGERED 38 · REFUSED 9 (152 PASS · 0 RED-EXPECTED — the last two closed 2026-08-23, §D.29) | `extract/figma/conformance/MANIFEST.json` (`npm run conformance:canvas`) |
+| canvas constructs | 154 | CARRIED 107 · LEDGERED 38 · REFUSED 9 (154 PASS · 0 RED-EXPECTED — the last two exam silences closed 2026-08-23, §D.29; the slot's interior layout the same day, §D.31) | `extract/figma/conformance/MANIFEST.json` (`npm run conformance:canvas`) |
 | dropped-fact receipts (`†`) and the facts they name | 104 receipts · 2,321 named facts | pinned exactly, in both directions; since 2026-08-22 every `†` carries its facts by part, channel, value and reason (`codeOnlyFacts`) | `extract/figma/dagger-census.json` (`npm run dagger:census`, `code-only-facts:check`) |
 
 **REFUSED and UNSUPPORTED are different facts** and the fixture counts them
@@ -2469,8 +2453,8 @@ one spec built without `grow`, now lowers it to `layoutSizingHorizontal
 FILL` like every other part class, so the carried fact survives
 regeneration. Two conformance cases were added for it
 (`slot-primary-axis-fill`, `rest-slot-primary-axis-fill`, both CARRIED).
-What the grow does **not** carry — the slot's interior auto-layout — is
-§B.24.
+What the grow did **not** carry — the slot's interior auto-layout — was
+§B.24 until r11 the same day; closed in §D.31.
 
 **Gates:** `npm run conformance:canvas` (152 cases · CARRIED 105 ·
 LEDGERED 38 · REFUSED 9 · 152 PASS · 0 RED-EXPECTED), `npx tsx
@@ -2618,8 +2602,8 @@ npm run conformance
 # its canvas half, MEASURED through the plugin engine + mock canvas + dump + propose (§C.3)
 npm run conformance:roundtrip     # → 46 cases · 26 round-tripped · 5 named · 15 refused by name · 0 SILENT
 
-# the canvas-construct fixture, incl. the held-out kit's cases (§D.24, §D.29)
-npm run conformance:canvas        # → 152 cases · 152 PASS · 0 RED-EXPECTED · 0 FAIL
+# the canvas-construct fixture, incl. the held-out kit's cases (§D.24, §D.29, §D.31)
+npm run conformance:canvas        # → 154 cases · 154 PASS · 0 RED-EXPECTED · 0 FAIL
 
 # every dropped-fact receipt and the facts it names (§C.3)
 npm run dagger:census             # → 104 receipts · 2,321 named facts, no drift
@@ -2690,6 +2674,59 @@ numbers are not reused; this is where they went.
 | §6 out of scope by decision | [§A.4](#a4-out-of-scope-by-decision--not-gaps) |
 | §6b the scale wall | [§B.19](#b19-the-scale-wall--intake-cost-is-linear-in-component-count-and-human) |
 | §7 how to check this yourself | [§E](#e--how-to-check-this-document-yourself) |
+
+## D.31 The exam SLOT's interior auto-layout — CLOSED
+
+**2026-08-23, r11 (`core/propose-figma.ts`).** The last named slot gap
+(§B.24): the native-SLOT branch of `buildPart` computed `primaryAxisGrow`
+and returned, so a slot drawn as a padded COLUMN with item spacing — the
+held-out kit's Card Content slot — came back as a bare flex item, and
+nothing said so (`exact-proposal:check` §49 pinned the slot's `layout` as
+exactly `{"grow":true}` so the silence had a shape).
+
+**Disposition: CARRIED, not ledgered — decided by reading.** A SLOT node on
+the canvas IS a frame with auto-layout (dump v1.31 captures its `layout`
+like any frame's; the REST mapper serializes its layoutMode / alignment /
+padding / itemSpacing), and its interior layout is the layout the
+consumer's content renders in. The schema already hosts `layout` and
+`tokens` on a slot part (42 first-party slot parts carry them —
+`ds.empty-state` actions, `ds.accordion-item` contentArea, `ds.tab-list`
+tabs); `emit-figma-script` builds the slot spec with `layoutSpec(part)` +
+`applyStyling`, and its runtime's `applyFrameSpec` writes layoutMode /
+alignment / padding / itemSpacing onto the created slot; `packages/core/
+src/css.ts` writes flex-direction / justify-content / align-items / gap /
+padding for any part that carries them. Every emitter re-draws what the
+proposer now carries, so no receipt was the honest answer.
+
+**The fix.** The SLOT branch walks the same three doors every FRAME and
+swap-convention slot-wrapper part walks — `invertNodeTokens` (gap /
+padding and the box channels, minted under `mintUnbound` or bound),
+`invertLayout` (direction / justify / align / wrap, with r10's primary-axis
+`grow` computed inside it by `primaryAxisGrow` — one rule, one
+implementation) and `invertLayoutByProp` (the per-variant split) — then
+the r9 cross-axis doors, opacity / effects, `nameFixedChildGeometry` and
+`attachTokens`, in the FRAME branch's order. Two container rules read the
+node class rather than the drawn child count, because a slot with no
+design-time content is still a container (its children are the
+consumer's): `invertLayout` carries an empty slot's justify / align, and
+the itemSpacing mint no longer waits for two drawn children. Nothing is
+invented — `accepts`, `defaultContent`, the FC-GEOMETRY-EXCLUDED receipt
+and the 152 prior cases did not move.
+
+**Gates:** conformance cases `slot-interior-auto-layout` +
+`rest-slot-interior-auto-layout` (authored RED-EXPECTED with the silence
+pinned in `observedCheck`, proven red, then re-recorded CARRIED); `npm run
+conformance:canvas` (154 cases · CARRIED 107 · LEDGERED 38 · REFUSED 9 ·
+154 PASS · 0 RED-EXPECTED); `npm run exact-proposal:check` §49 (now pins
+the FULL layout object `{direction, justify, align, grow}` on every shape)
+and §50 (the interior facts on their own: the layout block, the three
+minted channels, the layoutByProp split); `npm run accuracy:check`
+(`accuracy/grammar.json` pins 154 = 107 / 38 / 9); `npm run
+emitters:check`; `npx tsx conformance/canvas.ts` (46 cases, 0 SILENT);
+`npm run flowbite-dump-propose:check` (8 stems). The Flowbite eight draw no
+native SLOT and the first-party `figma/*.figma.js` are emitted from
+contracts, not proposed from dumps, so no golden and no figma script
+changed.
 
 ---
 

--- a/docs/24-what-works.md
+++ b/docs/24-what-works.md
@@ -383,10 +383,10 @@ filter that decides carriage scores 100% on a channel it never opened.
 
 | manifest | cases | breakdown | source |
 |---|---|---|---|
-| canvas constructs | 152 | CARRIED 105 · LEDGERED 38 · REFUSED 9 | `extract/figma/conformance/MANIFEST.json` |
+| canvas constructs | 154 | CARRIED 107 · LEDGERED 38 · REFUSED 9 | `extract/figma/conformance/MANIFEST.json` |
 | CSS / DOM frontier | 82 | CARRIED 42 · REFUSED 18 · UNSUPPORTED 18 · LOWERED 4 | `conformance/MANIFEST.json` |
 
-Of the 152 canvas constructs, **152** are `green`.
+Of the 154 canvas constructs, **154** are `green`.
 A construct that is neither carried nor named-refused is a hard failure of that
 suite — "it silently did nothing" is not an allowed outcome.
 
@@ -540,7 +540,7 @@ npm run capability:fresh
 | `examples/untitled-ui/renders/fidelity.json` | `0a468d6682bf` | 84,415 | Untitled UI scored fidelity table |
 | `extract/computed/out/**/numbers.json` | `d5bcd57769dc` | 1,056,246 | capture counts + determinism receipts — 184 files |
 | `extract/computed/out/**/scorecard.json` | `3f0067a3f412` | 16,283,364 | computed-equality per component — 184 files |
-| `extract/figma/conformance/MANIFEST.json` | `ae03f5783d7f` | 112,058 | canvas construct vocabulary |
+| `extract/figma/conformance/MANIFEST.json` | `b17a451f6eb3` | 117,548 | canvas construct vocabulary |
 | `extract/figma/dagger-census.json` | `a8445c32d0b1` | 6,112 | dropped-fact receipt census |
 | `extract/figma/roundtrip-uui/report.json` | `3f4d66b6b63c` | 7,704,705 | canvas→code→canvas round trip |
 

--- a/evals/results.json
+++ b/evals/results.json
@@ -1,7 +1,7 @@
 {
   "passed": 225,
   "total": 225,
-  "commit": "185ac23ddb006051c22d6d9a0c1e71ec3c21dbdc",
+  "commit": "8162d7c42c7b434d8769f5d024445365bb33cbbe",
   "dirty": false,
   "recordedAt": "2026-08-23",
   "results": [

--- a/examples/untitled-ui/LEDGER.md
+++ b/examples/untitled-ui/LEDGER.md
@@ -15,7 +15,7 @@ Fifteen Untitled UI component sets were drawn by hand on a Figma canvas, capture
 | instrument | what it holds the tool to | current reading | artifact |
 |---|---|---|---|
 | Pixel fidelity | a render of the emitted React vs the canvas reference, per variant | **92.7%** mean over 537 scored variants in 15 sets (best toggle-base 98.0%, worst tooltip 81.2%) | `renders/fidelity.json` |
-| Document-model conformance | one hand-authored case per Figma construct, with a hand-authored expected disposition | **152/152** green, 0 pinned red — 105 constructs expected CARRIED, 9 REFUSED, 38 LEDGERED | `extract/figma/conformance/MANIFEST.json` |
+| Document-model conformance | one hand-authored case per Figma construct, with a hand-authored expected disposition | **154/154** green, 0 pinned red — 107 constructs expected CARRIED, 9 REFUSED, 38 LEDGERED | `extract/figma/conformance/MANIFEST.json` |
 | Canvas→code→canvas round trip | every (variant ▸ node ▸ channel) fact, four ways | **15/15** executed to fact diff · **0/15 verified exact** · 11,400 matched · 1,857 diverged · 7,671 loss · 15,359 invented | `extract/figma/roundtrip-uui/report.json` |
 | The named-refusal surface | what the pipeline writes down when it will not carry something | **491** capture receipts in 8 codes · 15 stub contracts · 47 named conformance limits · 1 refused icon export | dumps, contracts, icon manifest |
 
@@ -43,7 +43,7 @@ Method, quoted from `renders/FIDELITY.md`: *Score = % of pixels REPRODUCED, meas
 
 ## 2. What carries
 
-The document-model fixture is the answer to "will it survive the boundary at all". It is 152 hand-authored cases whose expected disposition was written from the Figma documentation model, never from engine output; a construct that is neither carried nor named-refused is a hard failure. **105 constructs are proven CARRIED and green.** Grouped, with the case ids you can re-run:
+The document-model fixture is the answer to "will it survive the boundary at all". It is 154 hand-authored cases whose expected disposition was written from the Figma documentation model, never from engine output; a construct that is neither carried nor named-refused is a hard failure. **107 constructs are proven CARRIED and green.** Grouped, with the case ids you can re-run:
 
 | construct family | carried | case ids |
 |---|---|---|
@@ -59,9 +59,9 @@ The document-model fixture is the answer to "will it survive the boundary at all
 | Node opacity | 1 | `opacity-node` |
 | Absolute placement and constraints | 3 | `placement-abs-frame` `placement-fixedsize-inflow` `placement-xy-none-layout` |
 | Corner radii | 2 | `radius-uniform-bound` `radius-uniform-literal` |
-| `rest-*` | 4 | `rest-layout-sizing-vertical-fill` `rest-slot-primary-axis-fill` `rest-text-align-center` `rest-variables-captured` |
+| `rest-*` | 5 | `rest-layout-sizing-vertical-fill` `rest-slot-interior-auto-layout` `rest-slot-primary-axis-fill` `rest-text-align-center` `rest-variables-captured` |
 | Drawn geometry (ellipse, polygon, arc, rotated rect, vector) | 8 | `shape-arc-donut` `shape-arc-full` `shape-arc-partial` `shape-ellipse` `shape-polygon` `shape-polygon-no-sides` `shape-rect-abs` `shape-rotated-rect` |
-| Slots and preferred values | 5 | `slot-native-node` `slot-optional-show` `slot-preferred-values` `slot-primary-axis-fill` `slot-wrapper-swap` |
+| Slots and preferred values | 6 | `slot-interior-auto-layout` `slot-native-node` `slot-optional-show` `slot-preferred-values` `slot-primary-axis-fill` `slot-wrapper-swap` |
 | Spacers and growth | 2 | `spacer-growth` `spacer-visiblewhen` |
 | Sparse / minority children | 2 | `sparse-minority-child` `sparse-unpredictable` |
 | Strokes | 5 | `stroke-align-inside` `stroke-align-outside` `stroke-only-no-fill` `stroke-uniform-var` `stroke-weight-bound` |
@@ -244,7 +244,7 @@ Carried, but not carried perfectly. These are the classes an adopter will actual
 
 ### 5.1 The pinned reds
 
-NONE. All 152 conformance cases are green: every construct the documentation model says is CARRIED is carried, and every refusal is named. This section stays in the ledger because an empty pinned-red list is a reading, not a formatting accident — when a red returns it is printed here verbatim from the manifest.
+NONE. All 154 conformance cases are green: every construct the documentation model says is CARRIED is carried, and every refusal is named. This section stays in the ledger because an empty pinned-red list is a reading, not a formatting accident — when a red returns it is printed here verbatim from the manifest.
 
 ### 5.2 The round-1 audit, re-checked
 
@@ -299,7 +299,7 @@ npx tsx extract/figma/ledger/build.ts
 
 # 2 · the document-model fixture — fast, read-only, no engine changes
 npm run conformance:canvas
-#    expect: 152 case(s): 152 PASS, 0 RED-EXPECTED (pinned findings), 0 FAIL, 0 UNEXPECTED-GREEN, 0 UNLISTED, 0 MISSING
+#    expect: 154 case(s): 154 PASS, 0 RED-EXPECTED (pinned findings), 0 FAIL, 0 UNEXPECTED-GREEN, 0 UNLISTED, 0 MISSING
 
 # 3 · the canvas→code→canvas round trip (rewrites REPORT.md + report.json)
 npm run extract:figma:roundtrip:uui
@@ -324,7 +324,7 @@ npx tsx examples/untitled-ui/fidelity-score.mts
 | `examples/untitled-ui/storybook/contracts/` | `3e7f9bd2b2c0` | 131,804 | proposed contracts (30 files) |
 | `examples/untitled-ui/storybook/src/generated/` | `73ca6c3fd182` | 276,029 | emitted components (30 dirs) |
 | `examples/untitled-ui/storybook/src/tokens.css` | `8c31938a1627` | 674,804 | emitted global tokens |
-| `extract/figma/conformance/MANIFEST.json` | `ae03f5783d7f` | 112,058 | conformance denominator |
+| `extract/figma/conformance/MANIFEST.json` | `b17a451f6eb3` | 117,548 | conformance denominator |
 | `extract/figma/roundtrip-uui/report.json` | `3f4d66b6b63c` | 7,704,705 | round-trip facts |
 | `extract/figma/roundtrip-uui/REPORT.md` | `61f5c58f7f20` | 144,788 | round-trip narrative |
 

--- a/examples/untitled-ui/RESIDUALS.md
+++ b/examples/untitled-ui/RESIDUALS.md
@@ -481,7 +481,7 @@ None of the three steps rewrites `renders/FIDELITY.md`, `renders/fidelity.json` 
 | `examples/untitled-ui/renders/fidelity.json` | `0a468d6682bf` | 84,415 | fidelity table |
 | `examples/untitled-ui/renders/FIDELITY.md` | `3b0532cd2de8` | 4,242 | fidelity method |
 | `examples/untitled-ui/storybook/contracts/` | `3e7f9bd2b2c0` | 131,804 | proposed contracts (30 files) |
-| `extract/figma/conformance/MANIFEST.json` | `ae03f5783d7f` | 112,058 | conformance denominator |
+| `extract/figma/conformance/MANIFEST.json` | `b17a451f6eb3` | 117,548 | conformance denominator |
 | `extract/figma/roundtrip-uui/report.json` | `3f4d66b6b63c` | 7,704,705 | round-trip facts |
 
 Same bytes in, same file out: this build reads no clock, no git state and no environment, and sorts every collection before rendering.

--- a/extract/figma/conformance/MANIFEST.json
+++ b/extract/figma/conformance/MANIFEST.json
@@ -2143,6 +2143,52 @@
       "status": "green",
       "observed": "RE-RECORDED red -> green (r10, 2026-08-23, core/propose-figma.ts + core/emit-figma-script.ts). The native SLOT branch of buildPart now reads the primary-axis FILL through primaryAxisGrow — the ONE rule invertLayout (FRAME / spacer / slot-wrapper parts) reads, extracted rather than copied — so a SLOT that FILLS along its ROW parent's primary axis in every occurrence carries `layout.grow: true` on the slot part (the FRAME carriage, canvas conformance layout-fill-width-row). emit-figma-script's slot spec was the one spec built without `grow`; it now lowers a slot part's layout.grow to layoutSizingHorizontal FILL like every other part class, so the carried fact survives regeneration. Was: SILENT — the SLOT branch never called invertLayout, so the FILL reached neither `layout.grow` nor a note (the REST mapper already emitted fillWidth from layoutSizingHorizontal FILL on the SLOT document; the silence was propose-side).",
       "exam": "phase-2 FIGMA-DS exam RE-MEASURED 2026-08-23 (parity/receipts/phase-2/FIGMA-DS-EXAM.md) — r9 exam 2 finding, not fixed there"
+    },
+    {
+      "id": "slot-interior-auto-layout",
+      "construct": "a native SLOT child drawn as a padded COLUMN with item spacing (layoutMode VERTICAL, primary CENTER, counter MAX, itemSpacing 8, padding 12/16) and FILL-width under a FIXED-width ROW parent, in EVERY variant (Phase 2 exam: the Card Content slot's shape — docs/23 §B.24)",
+      "expect": "CARRIED",
+      "why": "a SLOT node on the canvas IS a frame with auto-layout (dump v1.31 captures its `layout` like any frame's; REST serializes layoutMode/alignment/padding/itemSpacing on the SLOT document), and its interior layout is the layout the consumer's content renders in — the same fact a FRAME part carries as `layout.direction/justify/align` (invertLayout) with gap and padding on the token channels (invertNodeTokens → mintUnbound). The schema hosts `layout` and `tokens` on a slot part (42 first-party slot parts carry them — ds.empty-state actions, ds.accordion-item contentArea, ds.tab-list tabs), emit-figma-script builds the slot spec with layoutSpec(part) + applyStyling (applyFrameSpec writes layoutMode/primary/counter/padding/itemSpacing onto the created slot), and packages/core/src/css.ts writes flex-direction/justify-content/align-items/gap/padding for any part with them — so the disposition is CARRIED, beside the r10 `layout.grow`",
+      "check": {
+        "carried": [
+          "\"slot\"",
+          "\"direction\":\"column\"",
+          "\"justify\":\"center\"",
+          "\"align\":\"end\"",
+          "\"grow\":true",
+          "\"gap\":\"\\{imported\\.case\\.s\\.gap\\}\"",
+          "\"\\$value\":\"8px\"",
+          "\"padding-inline\":\"\\{imported\\.case\\.s\\.padding-inline\\}\"",
+          "\"padding-block\":\"\\{imported\\.",
+          "\"\\$value\":\"12px\""
+        ]
+      },
+      "status": "green",
+      "observed": "RE-RECORDED red -> green (r11, 2026-08-23, core/propose-figma.ts). The native SLOT branch of buildPart now walks the SAME doors every FRAME and swap-convention slot-wrapper part walks — invertNodeTokens (gap / padding and the box channels), invertLayout (direction / justify / align / wrap, with r10's grow computed inside it by primaryAxisGrow) and invertLayoutByProp (the per-variant split) — so the slot part carries layout {direction: column, justify: center, align: end, grow: true} with gap / padding-inline / padding-block minted on its token channels. A slot with no drawn children is a container by definition: invertLayout's justify/align and the gap mint read m.type === 'SLOT', not the drawn child count. Was: SILENT — the branch computed primaryAxisGrow alone and returned (docs/23 §B.24; exact-proposal:check §49 pinned `layout` as exactly {\"grow\":true}).",
+      "exam": "phase-2 FIGMA-DS exam (parity/receipts/phase-2/FIGMA-DS-EXAM.md) — the Card Content slot; named in docs/23 §B.24 after r10, not fixed there"
+    },
+    {
+      "id": "rest-slot-interior-auto-layout",
+      "construct": "REST: a native SLOT document drawn layoutMode VERTICAL / primaryAxisAlignItems CENTER / counterAxisAlignItems MAX / itemSpacing 8 / padding 12,16 with layoutSizingHorizontal FILL under a FIXED-width ROW root (the REST twin of slot-interior-auto-layout, mapped through extract/figma/rest/map.ts)",
+      "expect": "CARRIED",
+      "why": "a SLOT node on the canvas IS a frame with auto-layout (dump v1.31 captures its `layout` like any frame's; REST serializes layoutMode/alignment/padding/itemSpacing on the SLOT document), and its interior layout is the layout the consumer's content renders in — the same fact a FRAME part carries as `layout.direction/justify/align` (invertLayout) with gap and padding on the token channels (invertNodeTokens → mintUnbound). The schema hosts `layout` and `tokens` on a slot part (42 first-party slot parts carry them — ds.empty-state actions, ds.accordion-item contentArea, ds.tab-list tabs), emit-figma-script builds the slot spec with layoutSpec(part) + applyStyling (applyFrameSpec writes layoutMode/primary/counter/padding/itemSpacing onto the created slot), and packages/core/src/css.ts writes flex-direction/justify-content/align-items/gap/padding for any part with them — so the disposition is CARRIED, beside the r10 `layout.grow`",
+      "check": {
+        "carried": [
+          "\"slot\"",
+          "\"direction\":\"column\"",
+          "\"justify\":\"center\"",
+          "\"align\":\"end\"",
+          "\"grow\":true",
+          "\"gap\":\"\\{imported\\.case\\.s\\.gap\\}\"",
+          "\"\\$value\":\"8px\"",
+          "\"padding-inline\":\"\\{imported\\.case\\.s\\.padding-inline\\}\"",
+          "\"padding-block\":\"\\{imported\\.",
+          "\"\\$value\":\"12px\""
+        ]
+      },
+      "status": "green",
+      "observed": "RE-RECORDED red -> green (r11, 2026-08-23, core/propose-figma.ts). Same fix as slot-interior-auto-layout; the REST mapper already emitted the SLOT document's layout and fillWidth, the silence was propose-side. This twin's root draws 12px inline padding and its label 12px type beside the slot's 12px block padding, so padding-block rides the shared-value mint ({imported.shared.size-12}) rather than a slot-named one — the probe pins the channel, not the mint spelling. Was: SILENT — the native SLOT branch computed primaryAxisGrow alone and returned (docs/23 §B.24).",
+      "exam": "phase-2 FIGMA-DS exam (parity/receipts/phase-2/FIGMA-DS-EXAM.md) — the Card Content slot; named in docs/23 §B.24 after r10, not fixed there"
     }
   ]
 }

--- a/extract/figma/conformance/cases/rest-slot-interior-auto-layout.rest.json
+++ b/extract/figma/conformance/cases/rest-slot-interior-auto-layout.rest.json
@@ -1,0 +1,209 @@
+{
+ "name": "canvas conformance fixture (REST boundary) — a native SLOT document drawn as a padded COLUMN with item spacing (layoutMode VERTICAL, primaryAxisAlignItems CENTER, counterAxisAlignItems MAX, itemSpacing 8, padding 12/16) and layoutSizingHorizontal FILL under a FIXED-width ROW root: the slot's interior auto-layout carries on the slot part like a FRAME part's (the REST twin of slot-interior-auto-layout; r11 2026-08-23)",
+ "nodes": {
+  "1:16": {
+   "document": {
+    "id": "1:16",
+    "name": "Case",
+    "type": "COMPONENT_SET",
+    "scrollBehavior": "SCROLLS",
+    "blendMode": "PASS_THROUGH",
+    "clipsContent": false,
+    "fills": [],
+    "strokes": [],
+    "strokeWeight": 1,
+    "strokeAlign": "INSIDE",
+    "absoluteBoundingBox": {
+     "x": 0,
+     "y": 0,
+     "width": 120,
+     "height": 80
+    },
+    "effects": [],
+    "interactions": [],
+    "layoutSizingHorizontal": "FIXED",
+    "layoutSizingVertical": "FIXED",
+    "constraints": {
+     "vertical": "TOP",
+     "horizontal": "LEFT"
+    },
+    "componentPropertyDefinitions": {
+     "Variant": {
+      "type": "VARIANT",
+      "defaultValue": "Default",
+      "variantOptions": [
+       "Default"
+      ]
+     },
+     "s#1:1": {
+      "type": "SLOT",
+      "defaultValue": {
+       "guid": {
+        "sessionID": -1,
+        "localID": -1
+       }
+      },
+      "preferredValues": [
+       {
+        "type": "COMPONENT_SET",
+        "key": "de1d1f4d9674a79e188e32cf71ea15dafc2355bf"
+       }
+      ]
+     }
+    },
+    "children": [
+     {
+      "id": "1:17",
+      "name": "Variant=Default",
+      "type": "COMPONENT",
+      "scrollBehavior": "SCROLLS",
+      "blendMode": "PASS_THROUGH",
+      "clipsContent": false,
+      "fills": [
+       {
+        "blendMode": "NORMAL",
+        "type": "SOLID",
+        "color": {
+         "r": 0.9,
+         "g": 0.92,
+         "b": 0.95,
+         "a": 1
+        }
+       }
+      ],
+      "strokes": [],
+      "strokeWeight": 1,
+      "strokeAlign": "INSIDE",
+      "cornerRadius": 0,
+      "layoutMode": "HORIZONTAL",
+      "primaryAxisAlignItems": "MIN",
+      "counterAxisAlignItems": "MIN",
+      "paddingLeft": 12,
+      "paddingRight": 12,
+      "paddingTop": 4,
+      "paddingBottom": 4,
+      "itemSpacing": 24,
+      "layoutWrap": "NO_WRAP",
+      "layoutSizingHorizontal": "FIXED",
+      "layoutSizingVertical": "HUG",
+      "absoluteBoundingBox": {
+       "x": 0,
+       "y": 0,
+       "width": 928,
+       "height": 96
+      },
+      "effects": [],
+      "interactions": [],
+      "constraints": {
+       "vertical": "TOP",
+       "horizontal": "LEFT"
+      },
+      "children": [
+       {
+        "id": "1:18",
+        "name": "s",
+        "type": "SLOT",
+        "scrollBehavior": "SCROLLS",
+        "blendMode": "PASS_THROUGH",
+        "clipsContent": false,
+        "fills": [],
+        "strokes": [],
+        "strokeWeight": 1,
+        "strokeAlign": "INSIDE",
+        "cornerRadius": 0,
+        "layoutMode": "VERTICAL",
+        "primaryAxisAlignItems": "CENTER",
+        "counterAxisAlignItems": "MAX",
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 12,
+        "paddingBottom": 12,
+        "itemSpacing": 8,
+        "layoutWrap": "NO_WRAP",
+        "layoutSizingHorizontal": "FILL",
+        "layoutSizingVertical": "HUG",
+        "absoluteBoundingBox": {
+         "x": 0,
+         "y": 0,
+         "width": 848,
+         "height": 48
+        },
+        "effects": [],
+        "interactions": [],
+        "constraints": {
+         "vertical": "TOP",
+         "horizontal": "LEFT"
+        },
+        "children": [],
+        "componentPropertyReferences": {
+         "slotContentId": "s#1:1"
+        }
+       },
+       {
+        "id": "1:20",
+        "name": "t",
+        "type": "TEXT",
+        "scrollBehavior": "SCROLLS",
+        "blendMode": "PASS_THROUGH",
+        "characters": "Case",
+        "fills": [
+         {
+          "blendMode": "NORMAL",
+          "type": "SOLID",
+          "color": {
+           "r": 0.1,
+           "g": 0.1,
+           "b": 0.1,
+           "a": 1
+          }
+         }
+        ],
+        "strokes": [],
+        "strokeWeight": 1,
+        "strokeAlign": "OUTSIDE",
+        "layoutSizingHorizontal": "HUG",
+        "layoutSizingVertical": "HUG",
+        "absoluteBoundingBox": {
+         "x": 0,
+         "y": 0,
+         "width": 40,
+         "height": 16
+        },
+        "effects": [],
+        "interactions": [],
+        "constraints": {
+         "vertical": "TOP",
+         "horizontal": "LEFT"
+        },
+        "style": {
+         "fontFamily": "Inter",
+         "fontPostScriptName": "Inter-Medium",
+         "fontStyle": "Medium",
+         "fontWeight": 500,
+         "fontSize": 12,
+         "textAlignHorizontal": "LEFT",
+         "textAlignVertical": "TOP",
+         "letterSpacing": 0,
+         "lineHeightPx": 16,
+         "lineHeightPercent": 100,
+         "lineHeightUnit": "PIXELS",
+         "textAutoResize": "WIDTH_AND_HEIGHT"
+        }
+       }
+      ],
+      "primaryAxisSizingMode": "FIXED",
+      "counterAxisSizingMode": "AUTO"
+     }
+    ]
+   },
+   "components": {
+    "8:8": {
+     "name": "Glyph",
+     "key": "glyphkey1"
+    }
+   },
+   "componentSets": {},
+   "styles": {}
+  }
+ }
+}

--- a/extract/figma/conformance/cases/slot-interior-auto-layout.dump.json
+++ b/extract/figma/conformance/cases/slot-interior-auto-layout.dump.json
@@ -1,0 +1,166 @@
+{
+ "_provenance": {
+  "fileKey": null,
+  "extractedAt": "2026-08-23",
+  "note": "Node-tree dump (extract/figma/dump.plugin.js, dump v1.31) — hand-authored (r11, 2026-08-23): a native SLOT child drawn as a padded COLUMN with item spacing (layoutMode VERTICAL, primary CENTER, counter MAX, itemSpacing 8, padding 12/16) and layoutSizingHorizontal FILL under a FIXED-width ROW parent, in EVERY variant (the Phase 2 exam's Card Content slot shape). A SLOT node IS a frame with auto-layout: its interior layout is the consumer content's layout, so it carries on the slot part exactly as a FRAME part's does (invertLayout + the gap/padding channels) beside the r10 grow.",
+  "dumpVersion": "1.31"
+ },
+ "Case": {
+  "setName": "Case",
+  "type": "COMPONENT_SET",
+  "nodeId": "1:42",
+  "propertyDefinitions": {
+   "Variant": {
+    "type": "VARIANT",
+    "defaultValue": "Default",
+    "variantOptions": [
+     "Default",
+     "Inline"
+    ]
+   },
+   "s#1:1": {
+    "type": "SLOT",
+    "preferredValues": [
+     {
+      "type": "COMPONENT_SET",
+      "key": "de1d1f4d9674a79e188e32cf71ea15dafc2355bf"
+     }
+    ]
+   }
+  },
+  "variants": [
+   {
+    "name": "Variant=Default",
+    "type": "COMPONENT",
+    "bbox": {
+     "width": 928,
+     "height": 96
+    },
+    "layout": {
+     "mode": "HORIZONTAL",
+     "primary": "MIN",
+     "counter": "MIN",
+     "spacing": 24,
+     "padding": [
+      0,
+      0,
+      0,
+      0
+     ],
+     "primarySizing": "FIXED",
+     "counterSizing": "AUTO"
+    },
+    "fill": {
+     "hex": "f0eeed"
+    },
+    "children": [
+     {
+      "name": "s",
+      "type": "SLOT",
+      "clipsContent": true,
+      "layout": {
+       "mode": "VERTICAL",
+       "primary": "CENTER",
+       "counter": "MAX",
+       "spacing": 8,
+       "padding": [
+        12,
+        16,
+        12,
+        16
+       ],
+       "primarySizing": "AUTO",
+       "counterSizing": "AUTO"
+      },
+      "propRefs": {
+       "slotContentId": "s"
+      },
+      "slotKey": "s#1:1",
+      "children": [],
+      "fillWidth": true
+     },
+     {
+      "name": "t",
+      "type": "TEXT",
+      "text": {
+       "characters": "Case",
+       "fontSize": 12,
+       "fontStyle": "Medium",
+       "lineHeight": 16,
+       "fontFamily": "Inter"
+      },
+      "fill": {
+       "hex": "1a1a1a"
+      }
+     }
+    ]
+   },
+   {
+    "name": "Variant=Inline",
+    "type": "COMPONENT",
+    "bbox": {
+     "width": 928,
+     "height": 96
+    },
+    "layout": {
+     "mode": "HORIZONTAL",
+     "primary": "MIN",
+     "counter": "MIN",
+     "spacing": 24,
+     "padding": [
+      0,
+      0,
+      0,
+      0
+     ],
+     "primarySizing": "FIXED",
+     "counterSizing": "AUTO"
+    },
+    "fill": {
+     "hex": "f0eeed"
+    },
+    "children": [
+     {
+      "name": "s",
+      "type": "SLOT",
+      "clipsContent": true,
+      "layout": {
+       "mode": "VERTICAL",
+       "primary": "CENTER",
+       "counter": "MAX",
+       "spacing": 8,
+       "padding": [
+        12,
+        16,
+        12,
+        16
+       ],
+       "primarySizing": "AUTO",
+       "counterSizing": "AUTO"
+      },
+      "propRefs": {
+       "slotContentId": "s"
+      },
+      "slotKey": "s#1:1",
+      "children": [],
+      "fillWidth": true
+     },
+     {
+      "name": "t",
+      "type": "TEXT",
+      "text": {
+       "characters": "Case",
+       "fontSize": 12,
+       "fontStyle": "Medium",
+       "lineHeight": 16,
+       "fontFamily": "Inter"
+      },
+      "fill": {
+       "hex": "1a1a1a"
+      }
+     }
+    ]
+   }
+  ]
+ }
+}

--- a/figma-sync/plugin/engine.receipt.json
+++ b/figma-sync/plugin/engine.receipt.json
@@ -1,7 +1,7 @@
 {
   "note": "Engine-bundle drift guard — scripts/build-plugin-zip.mjs refuses to package when a fresh bundle of figma-sync/plugin/engine/entry.ts (core barrel + baked tokens/contracts/icons) no longer matches this receipt. Re-record deliberately: node scripts/build-plugin-zip.mjs --update-engine-receipt",
-  "inputHash": "fa55ec943110b0472b219e7c0e305c4bc9d9f62378d4593055953025d9f7f848",
-  "minifiedBytes": 810892,
+  "inputHash": "9b21cd8805ac42a587bf6148da2129535e88523d9cdee9a9fe7128dd1ced46b5",
+  "minifiedBytes": 811089,
   "inputFiles": 138,
   "esbuild": "0.28.1"
 }


### PR DESCRIPTION
r11 against d5b5b0b1 (main had not moved; no merge needed).

- `core/propose-figma.ts`: the exam SLOT's interior auto-layout (direction, gap, padding, alignment) is inverted instead of dropped. 3 NUL bytes preserved (cp, not patch).
- Two new canvas-construct cases — `slot-interior-auto-layout` (dump) and `rest-slot-interior-auto-layout` (REST) — MANIFEST 152 → 154.
- Accuracy grammar 154 = 107 carried / 38 ledgered / 9 refused.
- Exact-proposal §49/§50 → 110 checks.
- docs/23 §B.24 closed and moved to §D.31; docs/24 rebuilt (`capability:report`), not hand-edited.
- Engine receipt re-recorded (propose is baked); LEDGER/RESIDUALS rebuilt.

Gates (all exit 0): tsc root + 4 packages · lint · format:check · test:cli · schema:fresh · figma:fresh · generated:fresh · capability:fresh · dagger:census · flowbite-bundle-fresh · ledger:fresh · contracts:migrate:check · accuracy:check · test:accuracy-contract · docs:check · ci:lanes · maintain (16 steps) · plugin:check · plugin:ui-check · exact-proposal-check (110) · flowbite-dump-propose-check (8 stems) · conformance:canvas (154 PASS / 0 / 0) · conformance/canvas.ts (0 SILENT) · emitters-check.

Full suite on the clean tree: 225/225 at 8162d7c4, recorded in `evals/results.json`.
