### PR TITLE
Sync spine — baselines know their dump grammar; 69 instrument-only conflicts reconciled; the 55 real decisions stay red for the owner

### DIFF
--- a/.github/workflows/sync-spine.yml
+++ b/.github/workflows/sync-spine.yml
@@ -68,12 +68,23 @@ jobs:
             exit 0
           fi
           mkdir -p sync/out
+          # Exit semantics are UNCHANGED (2026-08-08 decision: a red run IS the
+          # drift signal). The spine's exit code is captured only so the drift
+          # table (SPINE.md) can be copied into the job summary before the step
+          # re-raises that same exit code — the conclusion is the spine's own.
+          set +e
           if [ "$OPEN_PR" = "true" ]; then
             echo "SYNC_SPINE_OPEN_PR=true — the spine may open at most 1 PR this run (cursor-deduplicated)."
             npx tsx sync/spine.ts --run-id "gh-${GITHUB_RUN_ID}" --open-pr --max-prs 1
           else
             npx tsx sync/spine.ts --run-id "gh-${GITHUB_RUN_ID}"
           fi
+          rc=$?
+          set -e
+          echo "spine-exit=$rc" >> "$GITHUB_OUTPUT"
+          report="sync/out/gh-${GITHUB_RUN_ID}/SPINE.md"
+          if [ -f "$report" ]; then cat "$report" >> "$GITHUB_STEP_SUMMARY"; fi
+          exit "$rc"
 
       - name: upload drift report
         if: ${{ !cancelled() && steps.spine.outputs.skipped != 'true' }}

--- a/docs/23-known-limitations.md
+++ b/docs/23-known-limitations.md
@@ -588,12 +588,17 @@ Two named holes remain:
     dump script reads the stamp back (nine occurrences in
     `extract/figma/dump.plugin.js`, five in `parity/extract-figma.plugin.js`),
     and hop-4 dump→propose recovers the stamped names, `specHash` and
-    `version` from it (`flowbite-dump-propose:check`). What is still missing
-    is narrower: no headless path recomputes the v6 fingerprint off a REST
-    file dump and compares it to the stamp, so a canvas edit is still found
-    by a human clicking **Check Drift** in the plugin, never by CI. The REST
-    route cannot read shared plugin data at all — the stamp is plugin-only
-    — which is why the read half is an engine change and not a wiring one.
+    `version` from it (`flowbite-dump-propose:check`). **Second correction
+    (2026-08-23):** the read half DOES exist and runs on the scheduled
+    `sync-spine` lane — `sync/observe.ts` reads the v6 stamp back over REST
+    (`/nodes?plugin_data=shared`) and compares it to `sync/ledger.json`, and
+    catches un-restamped edits through the dump-v1 observation baseline
+    (`observed.dumpFingerprint`, tagged with the grammar that produced it).
+    What is true is narrower: the v6 fingerprint is never RECOMPUTED
+    headlessly (REST paint JSON cannot reproduce the plugin serialization),
+    so the stamp is compared, not re-derived — and the first six live runs
+    showed the baseline half is only as honest as its grammar tag
+    (`sync/README.md`, "Two fingerprint domains").
 
 **What it would take — an engine change** for the read half; the signing half
 is not buildable in-plugin.

--- a/evals/results.json
+++ b/evals/results.json
@@ -1,7 +1,7 @@
 {
   "passed": 225,
   "total": 225,
-  "commit": "0e710f871a1d99eeabe99c9c03e269a6c2302c8b",
+  "commit": "c27a6222c5c9ec63baa42082088ef22b58b85e6e",
   "dirty": false,
   "recordedAt": "2026-08-23",
   "results": [

--- a/evals/run.ts
+++ b/evals/run.ts
@@ -11427,15 +11427,16 @@ console.log(JSON.stringify({ assign, cross, ok: a.reactions.length }));
         lastSyncedVersionId: '41',
         lastSyncedAt: AT,
         direction: 'code→canvas',
-        observed: { dumpFingerprint: 'dumpv1:10', fileVersionId: '41', observedAt: AT },
+        observed: { dumpFingerprint: 'dumpv1:10', dumpVersion: 'g1', fileVersionId: '41', observedAt: AT },
         provenance: 'sync-record',
       };
-      const obs = (stamp: string, dump: string): SyncSetObservation => ({
+      const obs = (stamp: string, dump: string, dumpVersion = 'g1'): SyncSetObservation => ({
         fileKey: 'FILEKEY',
         setNodeId: '1:1',
         setName: 'Probe',
         stamp,
         dumpFingerprint: dump,
+        dumpVersion,
         fileVersionId: '42',
       });
 
@@ -11459,6 +11460,32 @@ console.log(JSON.stringify({ assign, cross, ok: a.reactions.length }));
         throw new Error(
           `a v5 stamp vs a v6 record with an agreeing baseline must be in-sync with a named incomparability note (got ${crossVersion.status})`,
         );
+
+      // THE INSTRUMENT MOVED, NOT THE CANVAS (live finding 2026-08-23): the
+      // REST mapper's dump grammar went 1.5 → 1.31 and every baseline's
+      // bytes moved with it — six scheduled spine runs reported 87 untouched
+      // sets as "designer edit". Baselines compare only WITHIN a grammar: a
+      // baseline under another grammar is named incomparable and is never
+      // canvas evidence, so the row rides the stamp instead.
+      const grammarMoved = syncClassifyRecord(record, HASH_A, obs('v6:100', 'dumpv1:99', 'g2'));
+      if (grammarMoved.status !== 'in-sync' || !grammarMoved.notes.some((n) => n.includes('instrument moved')))
+        throw new Error(
+          `a baseline under a different dump grammar must be incomparable (in-sync by stamp, note names the instrument) — got ${grammarMoved.status}: ${grammarMoved.notes.join('; ')}`,
+        );
+      if (grammarMoved.canvasEvidence !== 'stamp')
+        throw new Error(`a foreign-grammar baseline must not count as evidence (got ${grammarMoved.canvasEvidence})`);
+      const untagged = syncClassifyRecord(
+        { ...record, observed: { dumpFingerprint: 'dumpv1:10', fileVersionId: '41', observedAt: AT } },
+        HASH_A,
+        obs('v6:100', 'dumpv1:10'),
+      );
+      if (untagged.canvasEvidence !== 'stamp' || !untagged.notes.some((n) => n.includes('untagged')))
+        throw new Error('an untagged (pre-grammar) baseline must be named incomparable, never silently trusted');
+      // …and a stamp that moved under a foreign grammar is still canvas-ahead
+      // (the stamp is its own instrument).
+      const stampMovedForeign = syncClassifyRecord(record, HASH_A, obs('v6:101', 'dumpv1:10', 'g2'));
+      if (stampMovedForeign.status !== 'canvas-ahead')
+        throw new Error(`a moved stamp must classify canvas-ahead regardless of baseline grammar (got ${stampMovedForeign.status})`);
 
       // RED 2: contract-hash bump → code-ahead.
       const codeBump = syncClassifyRecord(record, HASH_B, obs('v6:100', 'dumpv1:10'));
@@ -11552,7 +11579,8 @@ console.log(JSON.stringify({ assign, cross, ok: a.reactions.length }));
         throw new Error('sync:ledger:check did not report the five-status fixture drift table');
       console.log(
         'sync-ledger-lockfile: canvas-edit→canvas-ahead, hash-bump→code-ahead, both→conflict, recorded-amend echo→in-sync ' +
-          '(unrecorded amend raises the named false alarm); serialization deterministic; offline gate green over the committed ledger',
+          '(unrecorded amend raises the named false alarm); a foreign-grammar or untagged baseline is incomparable, never drift; ' +
+          'serialization deterministic; offline gate green over the committed ledger',
       );
     },
   },

--- a/extract/figma/rest/map.ts
+++ b/extract/figma/rest/map.ts
@@ -1695,6 +1695,15 @@ function mapNode(
  *  this route, never silent evidence about the design. Plugin dumps and
  *  hand-authored fixtures carry NO captureGaps field → zero new notes there
  *  (byte-identity preserved); nothing keys on dumpVersion comparisons. */
+/** The dump grammar this mapper speaks. Exported so the sync ledger can tag
+ *  every observation baseline with the grammar that produced it
+ *  (sync/ledger.ts): a baseline recorded under one grammar is INCOMPARABLE
+ *  with a fingerprint computed under another — the instrument moved, not the
+ *  canvas. Bump it whenever the projection changes (2026-08-23 finding: the
+ *  1.5 → 1.31 move re-fingerprinted 87 baselines and six scheduled spine runs
+ *  reported them as designer edits). */
+export const REST_DUMP_VERSION = '1.31';
+
 const REST_CAPTURE_GAPS: readonly string[] = [
   'absolute placement on non-shape nodes (dump v1.7): not captured on this route — an out-of-flow FRAME/TEXT (e.g. a corner-pinned badge) re-enters the flow and renders in-line',
   'image fills (dump v1.7 imageFill / v1.9 imageHash): not captured on this route — an IMAGE paint (e.g. an avatar photo) is read as no fill and renders as an empty box',
@@ -1748,8 +1757,8 @@ export function mapRestToDump(nodesResponse: RestNodesResponse, options: MapOpti
   const provenance: NonNullable<DumpFile['_provenance']> & { captureGaps: string[] } = {
     fileKey: options.fileKey ?? null,
     extractedAt: new Date().toISOString().slice(0, 10),
-    note: 'Node-tree dump mapped from the Figma REST API (extract/figma/rest/map.ts, dump v1.31) for design→contract proposal.',
-    dumpVersion: '1.31',
+    note: `Node-tree dump mapped from the Figma REST API (extract/figma/rest/map.ts, dump v${REST_DUMP_VERSION}) for design→contract proposal.`,
+    dumpVersion: REST_DUMP_VERSION,
     captureGaps: [
       ...(options.variables ? [] : [variablesCaptureGap(variablesUnavailable)]),
       ...REST_CAPTURE_GAPS,

--- a/sync/README.md
+++ b/sync/README.md
@@ -48,6 +48,16 @@ not their own re-serialization.
   (`extract/figma/rest/map.ts`, the mapper built to be byte-compatible with
   the plugin dump). A designer edit does **not** restamp v6 — this baseline is
   what catches it, once `sync observe --update` has recorded one.
+- **`observed.dumpVersion`** tags the baseline with the dump grammar
+  (`REST_DUMP_VERSION` in the mapper) that produced it. Baselines compare
+  **only within a grammar**: when the mapper moves, every baseline's bytes move
+  with it, and that is the instrument, not the canvas. A baseline under another
+  grammar (or an untagged pre-2026-08-23 one) is named *incomparable* and never
+  counts as canvas evidence; `sync:ledger:check` refuses a committed ledger
+  whose baselines do not speak the mapper's current grammar, so a grammar bump
+  must ship with its live re-baseline. Measured 2026-08-23: the 1.5 → 1.31 move
+  shipped without one and six scheduled spine runs reported 87 untouched sets as
+  designer edits.
 
 ## Writers — every sync verb records what it just did
 
@@ -57,7 +67,9 @@ not their own re-serialization.
 | `ds-contracts figma publish` | code→canvas | contractHash per bundled contract at publish time, `pendingApply: true` — the canvas half is pending until a designer applies; cleared by the apply-side record or a confirming `observe --update` |
 | `npm run sync -- record --from-receipt <receipt.json>` | code→canvas | fileKey + setNodeId + v6 from a console-loop generation receipt — the verb the generate loops call after a receipt lands |
 | `npm run sync -- seed` | code→canvas | all committed console-loop receipts (first-party + foreign corpora), provenance `seeded-from-receipts` |
-| `npm run sync:observe -- --update` | (evidence only) | observation baselines for in-sync rows; adopts a post-publish restamp (clearing `pendingApply`, loudly) |
+| `npm run sync:observe -- --update` | (evidence only) | observation baselines for in-sync rows; adopts a post-publish restamp (clearing `pendingApply`, loudly); drops, by name, a baseline under a grammar the mapper no longer speaks on rows it cannot re-baseline |
+| `npm run sync:observe -- --repin id[,id…]` | (code half only) | the contract bytes moved by **bookkeeping** (a schema codemod, an anchor re-point) and the canvas provably did not — the observed stamp equals the ledger's — so `contractHash` is re-pinned to the current bytes and a fresh baseline recorded. **Refuses** any row whose stamp differs, is absent or is incomparable: that row needs `--adopt` or a re-apply, never a quiet re-pin |
+| `npm run sync:observe -- --adopt id[,id…] [--note …]` | canvas→code | the canvas is the truth for these rows: current contract hash + observed stamp + fresh baseline, `pendingApply` cleared, provenance `observe`. The after-merge step of a spine PR, and the record for a write nobody ledgered (a plugin apply, a rebuild whose receipt never reached `sync record`). Explicit ids only — never "all" |
 
 The CLI writers are **opt-in**: they record only when `sync/ledger.json`
 already exists in the cwd (this repo) or `DS_CONTRACTS_SYNC_LEDGER` names a
@@ -148,8 +160,9 @@ transport does the rest.
 ### The scheduled lane (.github/workflows/sync-spine.yml)
 
 Cron every 2 h + `workflow_dispatch`: report-only spine run, drift report
-uploaded as an artifact, **fails visibly** on drift (a red scheduled run IS
-the drift signal). Needs the `FIGMA_TOKEN` repository secret — the owner
+uploaded as an artifact and written to the job summary, **fails visibly** on
+drift (a red scheduled run IS the drift signal). Needs the `FIGMA_TOKEN`
+repository secret — the owner
 configures it; when absent the lane **skips by name** and stays green (a
 missing credential must never impersonate drift). Set the repository variable
 `SYNC_SPINE_OPEN_PR=true` to let the scheduled run open PRs (1 per run,
@@ -161,7 +174,9 @@ eval below.
 
 - `npm run sync:ledger:check` (fast lane) — offline: schema + deterministic
   bytes + every seeded record verified against the receipt it cites
-  (`parity/receipts/console-loop/**` is read-only evidence here) + the
+  (`parity/receipts/console-loop/**` is read-only evidence here) + every
+  baseline tagged with the mapper's current dump grammar (a grammar bump
+  without a live re-baseline refuses here, not on the cron) + the
   committed-fixture drift table classifying all five statuses.
 - eval `sync-ledger-lockfile` (`npm run eval -- --only sync-ledger`) — the
   red tests: hand-edited fingerprint → canvas-ahead naming the component,

--- a/sync/cli.ts
+++ b/sync/cli.ts
@@ -14,7 +14,7 @@
  *       records are marked provenance "seeded-from-receipts".
  *
  *   observe  [--fixture <fixture.json>] [--file-key K] [--update] [--json]
- *            [--ledger <path>]
+ *            [--repin id[,id…]] [--adopt id[,id…] [--note text]] [--ledger <path>]
  *       THE DRIFT ARITHMETIC. Reads the current canvas state headlessly —
  *       from a committed ObservationFixture (offline, gate-shaped) or live
  *       over the Figma REST API (FIGMA_TOKEN; per-set stamp via
@@ -23,7 +23,26 @@
  *       in-sync | code-ahead | canvas-ahead | conflict | untracked.
  *       Exit gate-style: 0 clean, 1 drift, 2 usage/config error.
  *       --update records observation baselines for in-sync rows (and adopts
- *       a post-publish restamp, clearing pendingApply — noted loudly).
+ *       a post-publish restamp, clearing pendingApply — noted loudly). A
+ *       baseline recorded under an older dump grammar (ledger.ts
+ *       observed.dumpVersion ≠ the mapper's REST_DUMP_VERSION) is
+ *       incomparable: --update re-records it where the row is in-sync and
+ *       DROPS it, loudly and by name, where it is not (it described nothing
+ *       the current instrument can re-measure).
+ *       --repin id[,id…] (implies --update): the contract bytes moved by a
+ *       bookkeeping change (a schema codemod, an anchor re-point) and the
+ *       canvas half is PROVABLY unchanged — the observed stamp equals the
+ *       ledger's — so re-pin contractHash to the current bytes without
+ *       claiming a write. REFUSES by name for any row whose stamp differs,
+ *       is absent, or is incomparable: a re-pin over a moved canvas would be
+ *       the echo-loop false negative. Measured 2026-08-23: schema 17 moved
+ *       104 contract hashes while 64 canvases carried the exact ledger stamp.
+ *       --adopt id[,id…] (implies --update): take the CANVAS as the truth for
+ *       these rows — record the current contract hash + the observed stamp +
+ *       a fresh baseline, direction canvas→code. This is the after-merge
+ *       step of a spine PR, and the record for a canvas write nobody ledgered
+ *       (a plugin apply, a console-loop rebuild whose receipt never reached
+ *       `sync record`). Explicit ids only, never "all"; --note is recorded.
  *
  *   pull     [--fixture <fixture.json>] [--file-key K] [--only id[,id…]]
  *            [--out sync/out] [--run-id id] [--ledger <path>]
@@ -40,12 +59,14 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import {
+  baselineComparableWith,
   contractHashOf,
   driftReport,
   recordCodeToCanvasSync,
   recordKey,
   type DriftRow,
   type LedgerRecord,
+  type ObservationBaseline,
   type SetObservation,
   type SyncLedger,
 } from './ledger.js';
@@ -256,7 +277,11 @@ async function observeCommand(args: string[]): Promise<number> {
   let ledger = loadLedger(ledgerPath);
   const fixturePath = flag(args, 'fixture');
   const fileKeyFilter = flag(args, 'file-key');
-  const update = has(args, 'update');
+  const repinIds = flag(args, 'repin')?.split(',').map((s) => s.trim()).filter(Boolean) ?? [];
+  const adoptIds = flag(args, 'adopt')?.split(',').map((s) => s.trim()).filter(Boolean) ?? [];
+  const update = has(args, 'update') || repinIds.length > 0 || adoptIds.length > 0;
+  if (has(args, 'repin') && repinIds.length === 0) usage('--repin needs id[,id…]');
+  if (has(args, 'adopt') && adoptIds.length === 0) usage('--adopt needs id[,id…] (explicit, never "all")');
 
   let observations: SetObservation[];
   let fileKeys: Set<string> | undefined;
@@ -296,24 +321,105 @@ async function observeCommand(args: string[]): Promise<number> {
 
   if (update) {
     const byNode = new Map(observations.map((o) => [`${o.fileKey ?? '(no-file)'}#${o.setNodeId}`, o]));
+    const now = new Date().toISOString();
+    const baselineOf = (obs: SetObservation): ObservationBaseline => ({
+      dumpFingerprint: obs.dumpFingerprint,
+      dumpVersion: obs.dumpVersion,
+      fileVersionId: obs.fileVersionId,
+      observedAt: now,
+    });
+    const byId = new Map(ledger.records.map((r) => [r.contractId, r]));
+    for (const id of [...repinIds, ...adoptIds])
+      if (!byId.has(id)) usage(`--repin/--adopt: ${id} is not a ledger record`);
+    const noteFlag = flag(args, 'note');
+
+    // --repin: the code bytes moved by bookkeeping; the canvas provably did
+    // not. Refuse anything short of an exact stamp match.
+    let repinned = 0;
+    for (const id of repinIds) {
+      const r = byId.get(id)!;
+      const obs = r.setNodeId ? byNode.get(`${r.fileKey ?? '(no-file)'}#${r.setNodeId}`) : undefined;
+      const currentHash = hashes.get(recordKey(r)) ?? null;
+      if (!obs) usage(`--repin ${id}: the set was not observed — nothing proves the canvas half`);
+      if (currentHash === null) usage(`--repin ${id}: contract ${r.contractPath ?? '(none)'} is unreadable — no hash to pin`);
+      if (obs.stamp === null || r.canvasFingerprint === null || obs.stamp !== r.canvasFingerprint)
+        usage(
+          `--repin ${id} REFUSED: canvas stamp ${obs.stamp ?? 'none'} ≠ ledger ${r.canvasFingerprint ?? 'none'} — ` +
+            'the canvas half is not provably unchanged; use --adopt (canvas is the truth) or re-apply from code',
+        );
+      if (r.pendingApply) usage(`--repin ${id} REFUSED: a publish is pending apply — the canvas has not adopted this contract`);
+      if (currentHash === r.contractHash) {
+        console.log(`  = ${id}: contract hash already matches the ledger — nothing to re-pin`);
+        continue;
+      }
+      repinned++;
+      console.log(`  ↻ ${id}: contractHash re-pinned ${r.contractHash?.slice(0, 19) ?? 'null'}… → ${currentHash.slice(0, 19)}… (stamp ${obs.stamp} unchanged)`);
+      byId.set(id, {
+        ...r,
+        contractHash: currentHash,
+        lastSyncedVersionId: obs.fileVersionId,
+        lastSyncedAt: now,
+        observed: baselineOf(obs),
+        provenance: 'observe',
+      });
+    }
+
+    // --adopt: the canvas is the truth for this row.
+    let adopted = 0;
+    for (const id of adoptIds) {
+      const r = byId.get(id)!;
+      const obs = r.setNodeId ? byNode.get(`${r.fileKey ?? '(no-file)'}#${r.setNodeId}`) : undefined;
+      const currentHash = hashes.get(recordKey(r)) ?? null;
+      if (!obs) usage(`--adopt ${id}: the set was not observed — nothing to adopt`);
+      if (currentHash === null) usage(`--adopt ${id}: contract ${r.contractPath ?? '(none)'} is unreadable — an adoption records the contract it lands on`);
+      const v6 = obs.stamp !== null && /^v6:\d+$/.test(obs.stamp) ? obs.stamp : null;
+      if (v6 === null)
+        console.log(
+          `  ⚠ ${id}: the set carries ${obs.stamp ?? 'no'} stamp (not a v6 value) — keeping the ledger's ${r.canvasFingerprint ?? 'null'}; ` +
+            'the baseline is the canvas evidence for this row',
+        );
+      adopted++;
+      const { pendingApply: _drop, ...rest } = r;
+      const why = `adopted from live observation ${now.slice(0, 10)}` + (noteFlag ? ` — ${noteFlag}` : '') + (r.note ? ` (prior: ${r.note})` : '');
+      console.log(`  ✚ ${id}: adopted canvas stamp ${v6 ?? r.canvasFingerprint} + contract hash ${currentHash.slice(0, 19)}… (canvas→code)`);
+      byId.set(id, {
+        ...rest,
+        contractHash: currentHash,
+        canvasFingerprint: v6 ?? r.canvasFingerprint,
+        lastSyncedVersionId: obs.fileVersionId,
+        lastSyncedAt: now,
+        direction: 'canvas→code',
+        observed: baselineOf(obs),
+        provenance: 'observe',
+        note: why,
+      });
+    }
+    ledger = { ...ledger, records: [...byId.values()] };
+
     let updated = 0;
+    let dropped = 0;
+    const touched = new Set([...repinIds, ...adoptIds]);
     ledger = {
       ...ledger,
       records: ledger.records.map((r) => {
+        if (touched.has(r.contractId)) return r;
         const obs = r.setNodeId ? byNode.get(`${r.fileKey ?? '(no-file)'}#${r.setNodeId}`) : undefined;
         if (!obs) return r;
         const row = report.rows.find((x) => x.key === recordKey(r));
         if (!row) return r;
         if (row.status === 'in-sync' && !r.pendingApply) {
           updated++;
-          return {
-            ...r,
-            observed: {
-              dumpFingerprint: obs.dumpFingerprint,
-              fileVersionId: obs.fileVersionId,
-              observedAt: new Date().toISOString(),
-            },
-          };
+          return { ...r, observed: baselineOf(obs) };
+        }
+        // A baseline the current grammar cannot re-measure on a row that is
+        // NOT in-sync: it names nothing about today's canvas. Drop it, by
+        // name, rather than carry evidence the instrument can no longer read.
+        if (r.observed !== null && !baselineComparableWith(r.observed, obs)) {
+          dropped++;
+          console.log(
+            `  ✂ ${r.contractId}: dropped baseline ${r.observed.dumpFingerprint} (dump grammar ${r.observed.dumpVersion ?? 'untagged'} → ${obs.dumpVersion}; row is ${row.status}, not re-baselined)`,
+          );
+          return { ...r, observed: null };
         }
         // A pendingApply record whose set now carries a DIFFERENT stamp than
         // the ledger recorded at publish time: the canvas was written after
@@ -328,11 +434,7 @@ async function observeCommand(args: string[]): Promise<number> {
           return {
             ...rest,
             canvasFingerprint: obs.stamp,
-            observed: {
-              dumpFingerprint: obs.dumpFingerprint,
-              fileVersionId: obs.fileVersionId,
-              observedAt: new Date().toISOString(),
-            },
+            observed: baselineOf(obs),
             provenance: 'observe' as const,
           };
         }
@@ -340,7 +442,10 @@ async function observeCommand(args: string[]): Promise<number> {
       }),
     };
     saveLedger(ledgerPath, ledger);
-    console.log(`✔ --update: ${updated} observation baseline(s) recorded → ${ledgerPath}`);
+    console.log(
+      `✔ --update: ${updated} observation baseline(s) recorded, ${repinned} re-pinned, ${adopted} adopted, ` +
+        `${dropped} incomparable baseline(s) dropped → ${ledgerPath}`,
+    );
   }
 
   return report.clean ? 0 : 1;

--- a/sync/fixtures/ledger.fixture.json
+++ b/sync/fixtures/ledger.fixture.json
@@ -14,6 +14,7 @@
       "direction": "code→canvas",
       "observed": {
         "dumpFingerprint": "dumpv1:2497296723",
+        "dumpVersion": "1.31",
         "fileVersionId": "41",
         "observedAt": "2026-08-07T00:00:00.000Z"
       },
@@ -32,6 +33,7 @@
       "direction": "code→canvas",
       "observed": {
         "dumpFingerprint": "dumpv1:3471646910",
+        "dumpVersion": "1.31",
         "fileVersionId": "41",
         "observedAt": "2026-08-07T00:00:00.000Z"
       },
@@ -50,6 +52,7 @@
       "direction": "code→canvas",
       "observed": {
         "dumpFingerprint": "dumpv1:1",
+        "dumpVersion": "1.31",
         "fileVersionId": "41",
         "observedAt": "2026-08-07T00:00:00.000Z"
       },
@@ -68,6 +71,7 @@
       "direction": "code→canvas",
       "observed": {
         "dumpFingerprint": "dumpv1:1",
+        "dumpVersion": "1.31",
         "fileVersionId": "41",
         "observedAt": "2026-08-07T00:00:00.000Z"
       },

--- a/sync/ledger-check.ts
+++ b/sync/ledger-check.ts
@@ -24,7 +24,16 @@
  *   4. a drift table over the committed fixture that stops classifying all
  *      five statuses — the gate-shaped offline variant of `sync observe`
  *      (the live variant needs FIGMA_TOKEN and runs by hand:
- *      `npm run sync:observe`).
+ *      `npm run sync:observe`);
+ *   5. any observation baseline recorded under a dump grammar other than the
+ *      one the mapper speaks now (extract/figma/rest/map.ts
+ *      REST_DUMP_VERSION). Such a baseline is incomparable — the scheduled
+ *      spine names it and ignores it — so the ledger is carrying evidence
+ *      nothing can re-measure. The repair is a live re-baseline
+ *      (`npm run sync:observe -- --update`, FIGMA_TOKEN), in the SAME change
+ *      that moved the grammar. Measured 2026-08-23: the 1.5 → 1.31 move
+ *      shipped without one and six scheduled runs reported 87 untouched sets
+ *      as designer edits.
  *
  * NOT checked on purpose: current contract hashes vs ledger hashes — a
  * contract editing ahead of its last sync is code-ahead DRIFT (observe's
@@ -35,6 +44,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { contractHashOf, driftReport, parseLedger, recordKey, serializeLedger } from './ledger.js';
 import { observationsFromFixture, type ObservationFixture } from './observe.js';
+import { REST_DUMP_VERSION } from '../extract/figma/rest/map.js';
 
 const ROOT = process.cwd();
 const failures: string[] = [];
@@ -88,6 +98,19 @@ for (const r of ledger.records) {
     fail(`${recordKey(r)}: contractPath ${r.contractPath} is not on disk`);
 }
 
+// 3b. Baselines speak the mapper's grammar ------------------------------------
+let baselines = 0;
+for (const r of ledger.records) {
+  if (r.observed === null) continue;
+  baselines++;
+  if (r.observed.dumpVersion !== REST_DUMP_VERSION)
+    fail(
+      `${recordKey(r)}: observation baseline ${r.observed.dumpFingerprint} was recorded under dump grammar ` +
+        `${r.observed.dumpVersion ?? '(untagged)'}; the mapper speaks ${REST_DUMP_VERSION} — incomparable. ` +
+        'Re-baseline in this change: `npm run sync:observe -- --update` (live, FIGMA_TOKEN)',
+    );
+}
+
 // 4. The offline drift table over the committed fixture ----------------------
 const fixture = JSON.parse(
   readFileSync(path.join(ROOT, 'sync', 'fixtures', 'canvas.rest.fixture.json'), 'utf8'),
@@ -132,6 +155,6 @@ if (failures.length > 0) {
 }
 console.log(
   `sync-ledger-check: ${ledger.records.length} record(s) ok (${cited} receipt-citing record(s) verified against the receipts they cite), ` +
-    'bytes deterministic, contract paths resolve; offline fixture drift table classifies ' +
-    'in-sync / code-ahead / canvas-ahead / conflict / untracked exactly.',
+    `bytes deterministic, contract paths resolve, ${baselines} baseline(s) speak dump grammar ${REST_DUMP_VERSION}; ` +
+    'offline fixture drift table classifies in-sync / code-ahead / canvas-ahead / conflict / untracked exactly.',
 );

--- a/sync/ledger.json
+++ b/sync/ledger.json
@@ -12,26 +12,27 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T05:49:25.504Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:3149716910",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/altitude/components/avatar.json"
     },
     {
       "contractId": "altitude.badge",
       "contractPath": "examples/altitude/contracts/badge.contract.json",
-      "contractHash": "sha256:42693246bc95a9fdcb34a06edca990fff6903ace039fdd01ec53788fead20322",
+      "contractHash": "sha256:058c0be8f0d46fdc11ec32a62a9eb053e69b39999e98eb34a047401df6b60807",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "60:10083",
       "canvasFingerprint": "v6:3977245456",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:43:10.768Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
-      "observed": null,
-      "provenance": "sync-record",
+      "observed": {
+        "dumpFingerprint": "dumpv1:2227710096",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
+      },
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/altitude/components/badge.json"
     },
     {
@@ -51,29 +52,39 @@
     {
       "contractId": "altitude.chip",
       "contractPath": "examples/altitude/contracts/chip.contract.json",
-      "contractHash": "sha256:d9a844ec9ff819bf7c0a266f06599b16beaf84723c681002ae259aa627c98b6b",
+      "contractHash": "sha256:a96d5815a6f2363bd2f198d365c1c34861e2254701267c210d4549d748d45aaf",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "60:10126",
       "canvasFingerprint": "v6:3288704793",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:43:13.030Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
-      "observed": null,
-      "provenance": "sync-record",
+      "observed": {
+        "dumpFingerprint": "dumpv1:1120798882",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
+      },
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/altitude/components/chip.json"
     },
     {
       "contractId": "altitude.divider",
       "contractPath": "examples/altitude/contracts/divider.contract.json",
-      "contractHash": "sha256:f7aa750a69c0eee18cf0dce137bfc9bf9e49a4b0c7f62544e92ead9d361d784c",
+      "contractHash": "sha256:d1a3d207664c02b0c931e2a57795b164b5f1dba5fdbeb3159b9091f6969c27fd",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "59:9713",
       "canvasFingerprint": "v6:1673250268",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:43:13.347Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
-      "observed": null,
-      "provenance": "sync-record",
+      "observed": {
+        "dumpFingerprint": "dumpv1:3506643804",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
+      },
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/altitude/components/divider.json"
     },
     {
@@ -93,29 +104,39 @@
     {
       "contractId": "altitude.iconclose",
       "contractPath": "examples/altitude/contracts/iconclose.contract.json",
-      "contractHash": "sha256:dfe8c8afc6ff9ade50fb951d2e969af2f10da920c7bd796233332a6f9e93a991",
+      "contractHash": "sha256:966af89b99cd59e9d4f9d4c42eb606e9417f88e25b354178bb8c98b3d55f57dc",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:3071",
       "canvasFingerprint": "v6:1912940653",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:43:14.336Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
-      "observed": null,
-      "provenance": "sync-record",
+      "observed": {
+        "dumpFingerprint": "dumpv1:319884819",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
+      },
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/altitude/components/icon-close.json"
     },
     {
       "contractId": "altitude.link",
       "contractPath": "examples/altitude/contracts/link.contract.json",
-      "contractHash": "sha256:a471ba09b99fc18c48c3bad31a102d53ec53b9c5b16e293a394c7d02c31fabcb",
+      "contractHash": "sha256:71d6f4a25bac985f6ab9e7ea1b994c71c708a9d609c1c65e98fa9b23c9e0889d",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "60:10102",
       "canvasFingerprint": "v6:3448013784",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:43:14.695Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
-      "observed": null,
-      "provenance": "sync-record",
+      "observed": {
+        "dumpFingerprint": "dumpv1:2060152440",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
+      },
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/altitude/components/link.json"
     },
     {
@@ -317,19 +338,20 @@
     {
       "contractId": "carbon.button",
       "contractPath": "examples/carbon/contracts/button.contract.json",
-      "contractHash": "sha256:7201cf38f4fff0d0df63ddb751a664cf9e6c629ea7301bdd187b26b47bcc058d",
+      "contractHash": "sha256:787ec93bfcb47927fffb480b545b5fd8b9f53815526481a6362a0b0505a8d9ce",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:5528",
       "canvasFingerprint": "v6:310064922",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:47:03.732Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2265055463",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:496601980",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/carbon/components/button.json"
     },
     {
@@ -440,84 +462,84 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T05:47:09.501Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:3506480767",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/carbon/components/toggle.json"
     },
     {
       "contractId": "ds.accordion-item",
       "contractPath": "contracts/accordion-item.contract.json",
-      "contractHash": "sha256:fed66585aebea07275fae3d68c06e585b1ac180997aae0b29fafd1f976106e7e",
+      "contractHash": "sha256:5d5b3d76d4a9885c6a1359084ee3e296c833f8215113312707f858abbc68d9ae",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:908",
       "canvasFingerprint": "v6:362055825",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:55:41.724Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2279062718",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:4120265292",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/accordion-item.json"
     },
     {
       "contractId": "ds.avatar-group",
       "contractPath": "contracts/avatar-group.contract.json",
-      "contractHash": "sha256:d859c01820125a9c5573f5192b799fc1b55c952167cf74f1bbf1836457d0a51a",
+      "contractHash": "sha256:1319966b2c4bc3687af859b1641a053b440bb99d34dc0cb63eef517177487e77",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1442",
       "canvasFingerprint": "v6:73520369",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:04.824Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2272707179",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:3692949204",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/avatar-group.json"
     },
     {
       "contractId": "ds.avatar",
       "contractPath": "contracts/avatar.contract.json",
-      "contractHash": "sha256:b446ab8c8a4b6c6133053265ab835ed1b1cc5dd44bd052f49b765ee5e405d2e6",
+      "contractHash": "sha256:2af91751359eca603025df323157c367778c11036e7dae3da73b83ed53933a0e",
       "fileKey": "BMjUA2ue5CaZXU4kufxL0z",
       "setNodeId": "4:300",
       "canvasFingerprint": "v6:1644631224",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-08T13:32:57.000Z",
+      "lastSyncedVersionId": "2388438498796415748",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3778221867",
-        "fileVersionId": "2385318059580510974",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:4064706845",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2388438498796415748",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/avatar.json"
     },
     {
       "contractId": "ds.badge",
       "contractPath": "contracts/badge.contract.json",
-      "contractHash": "sha256:70a28298b1353637d7e97abb2fab2b0558a79eb8e311f2ebeb4d8421ce5c7fa1",
+      "contractHash": "sha256:56193fadf3d194e5504eabaf435f550ae67640e707681ce64cc02a232074d68a",
       "fileKey": "BMjUA2ue5CaZXU4kufxL0z",
       "setNodeId": "4:313",
       "canvasFingerprint": "v6:4254819976",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-08T13:32:57.000Z",
+      "lastSyncedVersionId": "2388438498796415748",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3750294563",
-        "fileVersionId": "2385318059580510974",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:650431504",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2388438498796415748",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/badge.json"
     },
     {
@@ -530,84 +552,84 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-08T13:32:57.000Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:2412317579",
-        "fileVersionId": "2385318059580510974",
-        "observedAt": "2026-08-08T13:51:42.600Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/components/banner.json"
     },
     {
       "contractId": "ds.blockquote",
       "contractPath": "contracts/blockquote.contract.json",
-      "contractHash": "sha256:f7f4c969b399105f2bca01f4bd50690345add1cc3e12f14e79a9b9607900174c",
+      "contractHash": "sha256:6b9f79155d87d721a75d9bc4981e376e71821d313b240dba8e197731818588ad",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:958",
       "canvasFingerprint": "v6:4276955563",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:58:58.465Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2354359567",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:3874849251",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/blockquote.json"
     },
     {
       "contractId": "ds.breadcrumb-item",
       "contractPath": "contracts/breadcrumb-item.contract.json",
-      "contractHash": "sha256:f4e24f544a8ab429589ea3720166e821bdcefd4f0f436f3df197828cf7a5c84f",
+      "contractHash": "sha256:f8bdfa1bc35a6b0b6885c3a09b2977480fc834f8d68b6182dc5d5ba6fe9fbd66",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1274",
       "canvasFingerprint": "v6:1787875132",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:02.831Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3566764418",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:1134562763",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/breadcrumb-item.json"
     },
     {
       "contractId": "ds.breadcrumbs",
       "contractPath": "contracts/breadcrumbs.contract.json",
-      "contractHash": "sha256:6338ce0a2003cc40925cf0fac7f40d4390db5e2d5e21359b6bd77b4ae4a85e6a",
+      "contractHash": "sha256:466a710903a81a7d2d25135b4f01971f924abf20fe0dbbdc8f1574d34e1ba9b5",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1280",
       "canvasFingerprint": "v6:649210368",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:03.091Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3672305563",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:3381771355",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/breadcrumbs.json"
     },
     {
       "contractId": "ds.button",
       "contractPath": "contracts/button.contract.json",
-      "contractHash": "sha256:cb8c6dd3a6be620f97beceef934681b42cf806d26559c3443e4cab5ea06fd2bf",
+      "contractHash": "sha256:87e1d27a91ce78f8441f67ed50fcde75a2bc9880b132fbf7531a4c6c20175cdc",
       "fileKey": "BMjUA2ue5CaZXU4kufxL0z",
       "setNodeId": "4:412",
       "canvasFingerprint": "v6:3495939700",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-08T13:32:57.000Z",
+      "lastSyncedVersionId": "2388438498796415748",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:1357660242",
-        "fileVersionId": "2385318059580510974",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:1666010662",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2388438498796415748",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/button.json"
     },
     {
@@ -620,624 +642,654 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-08T13:32:57.000Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:784848269",
-        "fileVersionId": "2385318059580510974",
-        "observedAt": "2026-08-08T13:51:42.600Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/components/card.json"
     },
     {
       "contractId": "ds.chat-message-metadata",
       "contractPath": "contracts/chat-message-metadata.contract.json",
-      "contractHash": "sha256:aa35fd43306d214bc33de8411b72b570ec55c3ee6eca77d648e9e3a570f90b9a",
+      "contractHash": "sha256:cb306a22edef1f9a8caa32f2f4209d34d5b540699d9f616b87ef53cbed7eeed6",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1724",
       "canvasFingerprint": "v6:3272099092",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:09.647Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2516269458",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:3223228161",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/chat-message-metadata.json"
     },
     {
       "contractId": "ds.chat-message",
       "contractPath": "contracts/chat-message.contract.json",
-      "contractHash": "sha256:1c966d877b437d0c806c29d15cc8f314e6cb0a959ac69a723200493b233716b3",
+      "contractHash": "sha256:2b8a4cc9b072600e0b9be43a7632be0af489af7ee6307f540847de5f082afa02",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1778",
       "canvasFingerprint": "v6:2328098173",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:10.652Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2028778432",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:132659479",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/chat-message.json"
     },
     {
       "contractId": "ds.chat-system-message",
       "contractPath": "contracts/chat-system-message.contract.json",
-      "contractHash": "sha256:7ae85d66c117479f7ac51f4cd621c0781811c7a00d84d82e035f360f0ed3bfc1",
+      "contractHash": "sha256:dda775bac61d51268bca84decd648c5a68e2542d63054d76a59146473bf78952",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1739",
       "canvasFingerprint": "v6:1239964147",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:10.042Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3272616708",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:3382675890",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/chat-system-message.json"
     },
     {
       "contractId": "ds.checkbox",
       "contractPath": "contracts/checkbox.contract.json",
-      "contractHash": "sha256:8da993a80bf82696318b13fda375c68da53b6abbcb5d649b1f6ead1bf619701e",
+      "contractHash": "sha256:6f596c420399ca4c3d3e82095fac70bf094748c1f2742bcca676daa8b0506493",
       "fileKey": "BMjUA2ue5CaZXU4kufxL0z",
       "setNodeId": "4:594",
       "canvasFingerprint": "v6:2238650114",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-08T13:32:57.000Z",
+      "lastSyncedVersionId": "2388438498796415748",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:1948266487",
-        "fileVersionId": "2385318059580510974",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:2478388003",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2388438498796415748",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/checkbox.json"
     },
     {
       "contractId": "ds.citation",
       "contractPath": "contracts/citation.contract.json",
-      "contractHash": "sha256:d5e05fb0bf7292b23093d8cc4593a35caafff3d45fe177d9beb90623a6af41b4",
+      "contractHash": "sha256:fade303eef3a691ae9a1ac53ddeafefbff2177ee1c9a64f0844fb440726f7b23",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:971",
       "canvasFingerprint": "v6:3382273654",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:58:58.731Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:1662996363",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:134570909",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/citation.json"
     },
     {
       "contractId": "ds.code",
       "contractPath": "contracts/code.contract.json",
-      "contractHash": "sha256:a09ecd24db48505ec2e351ec456a505de1cef7e4d5628658732d32d1b6b734ca",
+      "contractHash": "sha256:922bcfaaddcc49c6b4d6036faef5f816db6604b238dfbe9d0b37e53b392b94fe",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:954",
       "canvasFingerprint": "v6:475555880",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:58:58.228Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3637466021",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:4031099918",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/code.json"
     },
     {
       "contractId": "ds.divider",
       "contractPath": "contracts/divider.contract.json",
-      "contractHash": "sha256:b89303e381c239c9dff527234d01fb97b617bb721b2fbab390beb5d9bb9b803b",
+      "contractHash": "sha256:4b2f8e6c8f17c90ccb96fe10156fe2837de03c4a0dec0dbf14ba4b3786146412",
       "fileKey": "BMjUA2ue5CaZXU4kufxL0z",
       "setNodeId": "4:599",
       "canvasFingerprint": "v6:3338360677",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-08T13:32:57.000Z",
+      "lastSyncedVersionId": "2388438498796415748",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
         "dumpFingerprint": "dumpv1:1794851804",
-        "fileVersionId": "2385318059580510974",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpVersion": "1.31",
+        "fileVersionId": "2388438498796415748",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/divider.json"
     },
     {
       "contractId": "ds.empty-state",
       "contractPath": "contracts/empty-state.contract.json",
-      "contractHash": "sha256:5bf6bd732708b7a01066d71d6b0356d21a18ba53d21816c79fd8e2fdfd8de988",
+      "contractHash": "sha256:1b777105c99beeb4b4b2c837e45f86db4b8e9a65d620e665a6d72e2d7668ce27",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1457",
       "canvasFingerprint": "v6:1979502124",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:05.193Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3491784799",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:1588402733",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/empty-state.json"
     },
     {
       "contractId": "ds.field",
       "contractPath": "contracts/field.contract.json",
-      "contractHash": "sha256:cb9051cd6d49f979dcd564bbbf81f7c540ae86812c007826bc848736072d9b53",
+      "contractHash": "sha256:f931549f0b7a5827f6ce22df6023bd2067d6d4f02cfc9cb45352f0d0e35e6909",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:742",
       "canvasFingerprint": "v6:615833569",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:55:39.093Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2980351814",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:2676795796",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/field.json"
     },
     {
       "contractId": "ds.heading",
       "contractPath": "contracts/heading.contract.json",
-      "contractHash": "sha256:1c1c8753bda8042baf34c19b028deddd55d8c4782428943ffa5e496ca642d41f",
+      "contractHash": "sha256:1339f24f04a3a5354ca21dcf253cdd756333fe006943b5dcff99b4f14765e1e1",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:947",
       "canvasFingerprint": "v6:822703176",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:58:57.762Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2668007609",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:1238368155",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/heading.json"
     },
     {
       "contractId": "ds.icon-button",
       "contractPath": "contracts/icon-button.contract.json",
-      "contractHash": "sha256:13363f4fbf4b07347d09cb5ca58da4d82e4bf65a3c128a183750cede526e8d1a",
+      "contractHash": "sha256:25be813983d02f004c1a765ea73236fe974293282d08ea00d63ab83bcce5c744",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:739",
       "canvasFingerprint": "v6:1073239359",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:55:38.656Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2720964517",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:306589473",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/icon-button.json"
     },
     {
       "contractId": "ds.kbd",
       "contractPath": "contracts/kbd.contract.json",
-      "contractHash": "sha256:14b886eb4fa98103e3738b12f200dc5513630fdc87b1ef8b45ad7ca484e7e355",
+      "contractHash": "sha256:294560286f4cf9e173b9d680e66bfc4d1e659a0e57cd57698adb719385469696",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:950",
       "canvasFingerprint": "v6:1502495576",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:58:58.032Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:794530658",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:3038354923",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/kbd.json"
     },
     {
       "contractId": "ds.list-item",
       "contractPath": "contracts/list-item.contract.json",
-      "contractHash": "sha256:986ed24139e4d4750e51d0795dbdbe1f8db4ad0a954f137b199b0e91e5a182f3",
+      "contractHash": "sha256:83919a84b0d1b1e04a4cbcb1bb5ecc2283a9584e0714ddeb6496ccf98e3290c2",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1296",
       "canvasFingerprint": "v6:3305958002",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:03.390Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:4236786016",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:2580230446",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/list-item.json"
     },
     {
       "contractId": "ds.list",
       "contractPath": "contracts/list.contract.json",
-      "contractHash": "sha256:b81e1437689beafdc19106994bbefe945f11c8aaf84b9e68240a6b4165d1bbae",
+      "contractHash": "sha256:8076ed10e14c99eba759f7454e999072f6af056344a4eacfee355e686bdfa851",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1404",
       "canvasFingerprint": "v6:2994839928",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:03.856Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:4264804022",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:2161274955",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/list.json"
     },
     {
       "contractId": "ds.metadata-list-item",
       "contractPath": "contracts/metadata-list-item.contract.json",
-      "contractHash": "sha256:4b3c81b3f318fc902d0faed8549145d36053866733a750f7a480231d0f14c365",
+      "contractHash": "sha256:99d72039aa0a764a9cd3ae3785bccfafe59f8490f3fa611b723a1fcb5465c988",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1407",
       "canvasFingerprint": "v6:108085772",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:04.195Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:1011744786",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:3474680320",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/metadata-list-item.json"
     },
     {
       "contractId": "ds.metadata-list",
       "contractPath": "contracts/metadata-list.contract.json",
-      "contractHash": "sha256:baed9cf3606794ac80fb5213c5f0ad150027aee72bfb7313ceec2468e14defd3",
+      "contractHash": "sha256:baf3d14d6b9c69a5caff9d3198f8f62024bb15e270576128e7ad88e9c370d4a7",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1416",
       "canvasFingerprint": "v6:4200369828",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:04.501Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:464061610",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:1875458055",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/metadata-list.json"
     },
     {
       "contractId": "ds.pagination",
       "contractPath": "contracts/pagination.contract.json",
-      "contractHash": "sha256:d97462631c44273537e747f173fa33783ac0a4a05bf8f1e326d93878b837a70e",
+      "contractHash": "sha256:b0c2daac308957a19a812d533ac144d25986a0325f1a6b53fc299e18a169c432",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:838",
       "canvasFingerprint": "v6:3346344777",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:55:40.683Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:992075153",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:2315734023",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/pagination.json"
     },
     {
       "contractId": "ds.progress-bar",
       "contractPath": "contracts/progress-bar.contract.json",
-      "contractHash": "sha256:8a5b717ccd43919a31090980b8fdf803bd88cf967339341e294b7edf80f62acb",
+      "contractHash": "sha256:06ea77f42fb21a97fc4e7664955d143ef11160480d35de2f6b114b6dce96e33d",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:659",
       "canvasFingerprint": "v6:3162590889",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:55:24.165Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3511886852",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:3918428932",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/progress-bar.json"
     },
     {
       "contractId": "ds.section",
       "contractPath": "contracts/section.contract.json",
-      "contractHash": "sha256:dcccc6fba217c16e463e211b3a44f0637b94a3ab21ed32ef1da3d31bc019cc62",
+      "contractHash": "sha256:b9b92673088d767a8f1146b4bbe867fd50d0098c0c871924b5dcc10c328d0fa7",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1476",
       "canvasFingerprint": "v6:3994772349",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:05.633Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:1557040614",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:2118560066",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/section.json"
     },
     {
       "contractId": "ds.side-nav-item",
       "contractPath": "contracts/side-nav-item.contract.json",
-      "contractHash": "sha256:6fcc87a3c47d9625011bfa2b2abd52fc83010be39d2e910dc0ee5366a08ab59e",
+      "contractHash": "sha256:058bdcb7034587b5eaf838ebf7408ecc1a0eda3cb57bc619259b43a7cf52fc69",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1495",
       "canvasFingerprint": "v6:4041151291",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:06.107Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2930226781",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:1980335563",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/side-nav-item.json"
     },
     {
       "contractId": "ds.skeleton",
       "contractPath": "contracts/skeleton.contract.json",
-      "contractHash": "sha256:6e3302cb9216e68a4e38d7a5fa8503044267dff23158e1b3281263a38f0db9d8",
+      "contractHash": "sha256:4d0c4c1515d368bf905d40c2f7d4889b98447061792f9a2983e4ec83d2394c56",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:679",
       "canvasFingerprint": "v6:2572131761",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:55:24.616Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3818082324",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:1518934740",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/skeleton.json"
     },
     {
       "contractId": "ds.slider",
       "contractPath": "contracts/slider.contract.json",
-      "contractHash": "sha256:b0221bd574ac25381097c2783d2b054cea74a153519b62d1406a598db8cf6369",
+      "contractHash": "sha256:bda231dd448796017474db691dd9683e3362a882d77667aed08c2b718f415aaa",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:682",
       "canvasFingerprint": "v6:1021231104",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:55:38.270Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3823760448",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpFingerprint": "dumpv1:2383121865",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/slider.json"
     },
     {
       "contractId": "ds.spinner",
       "contractPath": "contracts/spinner.contract.json",
-      "contractHash": "sha256:fa5db35f0879326ce05537b9aaf9bfd8557ca99fa3b73543adecce3f32f0669b",
+      "contractHash": "sha256:c4d05c76306548f24c7bbaf2ac28ae9e3a4d7ae90d21c5d1b2a8154164bc52de",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:639",
       "canvasFingerprint": "v6:592169333",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:55:23.903Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
         "dumpFingerprint": "dumpv1:3269269541",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.600Z"
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/spinner.json"
     },
     {
       "contractId": "ds.status-dot",
       "contractPath": "contracts/status-dot.contract.json",
-      "contractHash": "sha256:b0999fa31c9d2dfe0db7ee57b5bd1a2f66cb65b0c4ba16a2d9160c434d0e6c74",
+      "contractHash": "sha256:e41d415af4afeef263fef2b4be5f0270c2a6066981a24680eab245b92fc27286",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:667",
       "canvasFingerprint": "v6:938381755",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:55:24.416Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
         "dumpFingerprint": "dumpv1:3888203497",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/status-dot.json"
     },
     {
       "contractId": "ds.switch",
       "contractPath": "contracts/switch.contract.json",
-      "contractHash": "sha256:6043693e8160abc8c6c32ac0f153121a54403d2c45f8fb818c099af7795183c4",
+      "contractHash": "sha256:e4360d3015a36eca1b0440d7b6d026b9a86e528503e30a83a6ccc3b6792cd8f8",
       "fileKey": "BMjUA2ue5CaZXU4kufxL0z",
       "setNodeId": "4:618",
       "canvasFingerprint": "v6:2653995724",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-08T13:32:57.000Z",
+      "lastSyncedVersionId": "2388438498796415748",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3135940853",
-        "fileVersionId": "2385318059580510974",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:915203117",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2388438498796415748",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/switch.json"
     },
     {
       "contractId": "ds.tab-list",
       "contractPath": "contracts/tab-list.contract.json",
-      "contractHash": "sha256:c2b90a701865a29b4d8a42f80ee48e4e2ade4779602377c9692155f34faa656c",
+      "contractHash": "sha256:2621206bbdf5b1c2ca8c1263412f795a70b561a9b96e4c15f2a0fd510e64c270",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:860",
       "canvasFingerprint": "v6:2665649309",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:55:41.390Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:215814069",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:3455218876",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/tab-list.json"
     },
     {
       "contractId": "ds.tab",
       "contractPath": "contracts/tab.contract.json",
-      "contractHash": "sha256:48da5adc170ba095f9e0d7b512de701a32ea06d4459416191554a60af0d623fd",
+      "contractHash": "sha256:962ceb3ea90725154c4983993ebf75c122ba0afe5217d3d18fc655a61f6e0f2c",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:857",
       "canvasFingerprint": "v6:2164586031",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:55:41.057Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:1417138273",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:380235727",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/tab.json"
     },
     {
       "contractId": "ds.table-cell",
       "contractPath": "contracts/table-cell.contract.json",
-      "contractHash": "sha256:bfb64aa9bed5e439bca204025053e78c053b0a47a48f13a45b559cb531a8f9a6",
+      "contractHash": "sha256:79e333f8515aa43175deaf71d14231bf32650d0e345b87f93d7798c2c26c1b9e",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1511",
       "canvasFingerprint": "v6:3685392620",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:06.888Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:323340422",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:433754616",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/table-cell.json"
     },
     {
       "contractId": "ds.table-header-cell",
       "contractPath": "contracts/table-header-cell.contract.json",
-      "contractHash": "sha256:2e7f8839b5494e5c2af932e12f4a7e7584895d97c1e66132c7dbeb434fdda795",
+      "contractHash": "sha256:01c94b8299ae729d6d93eedec67f9d4c9d19ba5ba268bbf9e683088076e55fd1",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1518",
       "canvasFingerprint": "v6:768570304",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:07.214Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3362513651",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:2664972485",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/table-header-cell.json"
     },
     {
       "contractId": "ds.table-row",
       "contractPath": "contracts/table-row.contract.json",
-      "contractHash": "sha256:fed41fde52c9eba646707a807e9d0338498bf11fecf86ccf0e8da6a2fb9db3e3",
+      "contractHash": "sha256:55f6ac5504a71b714292eba214cc89a6e2b55e14951b02864c65ef62f21d21e6",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1537",
       "canvasFingerprint": "v6:3502734612",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:07.553Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2406069605",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:3561042021",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/table-row.json"
     },
     {
       "contractId": "ds.table",
       "contractPath": "contracts/table.contract.json",
-      "contractHash": "sha256:7c687e7372b3b393400e48b780dcbf59bd5e0ef7e8b2f9cf67c95f44ce3566cf",
+      "contractHash": "sha256:e24f572b5582bc59b9c252608e2d0ad73931fc2a026956843be87e94d17f168d",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1623",
       "canvasFingerprint": "v6:772848675",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:08.063Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:479657509",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:3073040933",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/table.json"
     },
     {
       "contractId": "ds.text-area",
       "contractPath": "contracts/text-area.contract.json",
-      "contractHash": "sha256:f61a79804e5b22095d906552a333b12e9338438cda0cc6ad807e4086e2d9e28b",
+      "contractHash": "sha256:4134a810795981d1b44b987421445845747a65a41b5aa14b78ef7a03acf6c2f8",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1271",
       "canvasFingerprint": "v6:1681029316",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:02.492Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:1671773342",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:2371069263",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/text-area.json"
     },
     {
       "contractId": "ds.text-field",
       "contractPath": "contracts/text-field.contract.json",
-      "contractHash": "sha256:81e248a95ad3af107a1e9e29675090a486d92762088e93ea9350b9461e7acadd",
+      "contractHash": "sha256:21199edf26c0a01db00761f72d7bc33f8d31f7c4d9e6bc1dcc6f91d19a161438",
       "fileKey": "BMjUA2ue5CaZXU4kufxL0z",
       "setNodeId": "4:651",
       "canvasFingerprint": "v6:1181024118",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-08T13:32:57.000Z",
+      "lastSyncedVersionId": "2388438498796415748",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:560682207",
-        "fileVersionId": "2385318059580510974",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:1190214256",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2388438498796415748",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/text-field.json"
     },
     {
       "contractId": "ds.toast",
       "contractPath": "contracts/toast.contract.json",
-      "contractHash": "sha256:91c8c233834a9754f8d7ecdbb4c890ed22a23085b1af09508f80274ea828f3e6",
+      "contractHash": "sha256:16e93b75ad4ee11e20f25e9022236700e1de44b8a01073f23d000074037eddf2",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:802",
       "canvasFingerprint": "v6:3355364986",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:55:40.054Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2140310206",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:3003253434",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/toast.json"
     },
     {
@@ -1250,84 +1302,84 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-08T13:32:57.000Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:878597391",
-        "fileVersionId": "2385318059580510974",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/components/token.json"
     },
     {
       "contractId": "ds.toolbar",
       "contractPath": "contracts/toolbar.contract.json",
-      "contractHash": "sha256:08f43d20e7dfd887ae4a226f58c4f7516071b2a520162d8d09b0e0eb6bcbd1b6",
+      "contractHash": "sha256:fc7bbef111efb896b2f0475504953155eb8efd7208514360771cd3c30437f98a",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1656",
       "canvasFingerprint": "v6:700448191",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:08.439Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:702474289",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:292303745",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/toolbar.json"
     },
     {
       "contractId": "ds.top-nav-item",
       "contractPath": "contracts/top-nav-item.contract.json",
-      "contractHash": "sha256:d7842527971f7aa303252c8c55ecd6fe6c7198df9cfd07b2d14585fc41f4ad60",
+      "contractHash": "sha256:5aa5ea4b36f205db6bfbd319e77cb8c62c9823b677b1dbf81c1a97c9519c775e",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1669",
       "canvasFingerprint": "v6:2704633324",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:08.837Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:1883901480",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:1314675734",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/top-nav-item.json"
     },
     {
       "contractId": "ds.top-nav",
       "contractPath": "contracts/top-nav.contract.json",
-      "contractHash": "sha256:2ca77d2b4a95498839d4a27dab6d58bbc671e09cd8d3c48a313a31e14dabfcbb",
+      "contractHash": "sha256:ca79c6aebf4489cd43810a0933168a1e2361361a3441e3dda1b467a5c2d32347",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1672",
       "canvasFingerprint": "v6:3533008205",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:09.096Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3573897948",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:3469212260",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/top-nav.json"
     },
     {
       "contractId": "ds.typeahead-item",
       "contractPath": "contracts/typeahead-item.contract.json",
-      "contractHash": "sha256:0809df76911528cd2da922075a7f375bf5b5c0df2b32c46d265e6f532d215ced",
+      "contractHash": "sha256:5bdaaa58dabb1677be07087b1925116df97b622614f68b656f7e3387ea84a89a",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:1498",
       "canvasFingerprint": "v6:599440583",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T03:59:06.447Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:1390565902",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:3858385212",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/components/typeahead-item.json"
     },
     {
@@ -1347,19 +1399,20 @@
     {
       "contractId": "flowbite.badge",
       "contractPath": "examples/tailwind/contracts/badge.contract.json",
-      "contractHash": "sha256:264068df0c0a086b0f39893030b3dec3b31205550286a00b450eb049efe9b85e",
+      "contractHash": "sha256:ed23d808ac5680c445b143e52c4362ee6cc5b6d761dc6733233b862ef684cb54",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:2149",
       "canvasFingerprint": "v6:2933199349",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:42:56.743Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3551633168",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:865067787",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/tailwind/components/badge.json"
     },
     {
@@ -1379,20 +1432,21 @@
     {
       "contractId": "flowbite.card",
       "contractPath": "examples/tailwind/contracts/card.contract.json",
-      "contractHash": "sha256:d9b5bcbefb68dfb9074ea58a3db312c9ac8c3d4343e42839bea75e4895f143df",
+      "contractHash": "sha256:566070ab47bce9bdaf4383bcb1d768e91a5b46e41314892cb50525b94ed7d666",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:2267",
-      "canvasFingerprint": "v6:3067143140",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:42:58.099Z",
-      "direction": "code→canvas",
+      "canvasFingerprint": "v6:1646135488",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:35.595Z",
+      "direction": "canvas→code",
       "observed": {
-        "dumpFingerprint": "dumpv1:980311055",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:1126456408",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
-      "note": "receipt parity/receipts/console-loop/tailwind/components/card.json"
+      "provenance": "observe",
+      "note": "adopted from live observation 2026-08-23 — restamped by an unrecorded write between 2026-08-09 and 2026-08-21 (Figma version history: TJ Pitre); the dump-v1 projection under the 2026-08-08 mapper (8ac96363) is byte-identical to the 2026-08-08 baseline — content unchanged, stamp adopted (scratchpad REPORT 2026-08-23) (prior: receipt parity/receipts/console-loop/tailwind/components/card.json)"
     },
     {
       "contractId": "flowbite.toggleswitch",
@@ -1404,11 +1458,7 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T05:42:58.542Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:3619871677",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/tailwind/components/toggle-switch.json"
     },
@@ -1422,11 +1472,7 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T04:51:10.513Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:28072018",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/accordion.json"
     },
@@ -1440,30 +1486,27 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T05:17:13.440Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:381823219",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/alert.json"
     },
     {
       "contractId": "mui.autocomplete",
       "contractPath": "examples/mui/contracts/autocomplete.contract.json",
-      "contractHash": "sha256:0e74f5f37b35a79e986df4e65980869d24f31db25b0382f906a2bd036a5a3112",
+      "contractHash": "sha256:8948aab5fdd956a62166858d0613c09ac54acb264a7d728e6a00bbe1e781c965",
       "fileKey": "59mLQlOMiD5w5za6SUcoO5",
       "setNodeId": "21:134",
       "canvasFingerprint": "v6:1521385897",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T04:51:10.513Z",
+      "lastSyncedVersionId": "2389961688576685812",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:3440285766",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:4187961574",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2389961688576685812",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/mui/components/autocomplete.json"
     },
     {
@@ -1476,11 +1519,7 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T05:00:34.663Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:2673474047",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/avatar.json"
     },
@@ -1494,66 +1533,65 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T05:22:31.359Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:1650325718",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/badge.json"
     },
     {
       "contractId": "mui.breadcrumbs",
       "contractPath": "examples/mui/contracts/breadcrumbs.contract.json",
-      "contractHash": "sha256:da354a3d8124319adcd1497684e7186717f3e98d893c6b60b0dcf35d27bbb2f2",
+      "contractHash": "sha256:3697afdf7b7c29738ff951fd26e13d107b20c91068fd2f904c6da82a59d0b21b",
       "fileKey": "59mLQlOMiD5w5za6SUcoO5",
       "setNodeId": "83:1658",
       "canvasFingerprint": "v6:1233132133",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:00:36.193Z",
+      "lastSyncedVersionId": "2389961688576685812",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:805478728",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:1936982772",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2389961688576685812",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/mui/components/breadcrumbs.json"
     },
     {
       "contractId": "mui.button",
       "contractPath": "examples/mui/contracts/button.contract.json",
-      "contractHash": "sha256:941dc92b327dff855577583d6bd3ce659d5169ba445918d41ea7282de153e9fa",
+      "contractHash": "sha256:e85afbfc38e2591a369cfd5a66da253fb0445a4f4f2a2e464dca5e36b9f405e3",
       "fileKey": "59mLQlOMiD5w5za6SUcoO5",
       "setNodeId": "21:287",
       "canvasFingerprint": "v6:437388687",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T04:51:10.510Z",
-      "direction": "code→canvas",
+      "lastSyncedVersionId": "2389961688576685812",
+      "lastSyncedAt": "2026-08-23T12:52:39.983Z",
+      "direction": "canvas→code",
       "observed": {
-        "dumpFingerprint": "dumpv1:3123763879",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:2415220176",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2389961688576685812",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
-      "note": "receipt parity/receipts/console-loop/mui/components/button.json"
+      "provenance": "observe",
+      "note": "adopted from live observation 2026-08-23 — set carries a v5-era stamp (pre-v6 engine) while the receipt recorded a freshly computed v6 — two instruments, not a write; the dump-v1 projection under the 2026-08-08 mapper equals the 2026-08-08 baseline — content unchanged, re-baselined under grammar 1.31 (prior: receipt parity/receipts/console-loop/mui/components/button.json)"
     },
     {
       "contractId": "mui.card",
       "contractPath": "examples/mui/contracts/card.contract.json",
-      "contractHash": "sha256:ce6e431d950484f70284d5f5747f03b7ea7a0095ebea5c7f1c43af4c604b23ce",
+      "contractHash": "sha256:2d0d51eec80e244ee18ece0f3d590cde8b13c100f1af35a400483ded99025e34",
       "fileKey": "59mLQlOMiD5w5za6SUcoO5",
       "setNodeId": "21:308",
       "canvasFingerprint": "v6:2926211222",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T04:51:10.511Z",
+      "lastSyncedVersionId": "2389961688576685812",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2028771623",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:3693583755",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2389961688576685812",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/mui/components/card.json"
     },
     {
@@ -1566,66 +1604,65 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T04:51:10.514Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:833124426",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/checkbox.json"
     },
     {
       "contractId": "mui.chip",
       "contractPath": "examples/mui/contracts/chip.contract.json",
-      "contractHash": "sha256:161992c91320471b5341565a42bda1f1d94545ebabd637492aaeb7c587703e16",
+      "contractHash": "sha256:18642235b52a33ddab8777f0e3123a9748f38137e28ec446635fbef783656905",
       "fileKey": "59mLQlOMiD5w5za6SUcoO5",
       "setNodeId": "21:410",
       "canvasFingerprint": "v6:1499592056",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T04:51:10.511Z",
+      "lastSyncedVersionId": "2389961688576685812",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:503719763",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:2168689507",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2389961688576685812",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/mui/components/chip.json"
     },
     {
       "contractId": "mui.circular-progress",
       "contractPath": "examples/mui/contracts/circular-progress.contract.json",
-      "contractHash": "sha256:308cf77329cb9542b1160cec3aeec65a32ffc55907c665789e890d973a2fd6cc",
+      "contractHash": "sha256:895fd2928a63161be36e405fdb74beb03cc4f4d80a52b566a399d5c73f94e6ed",
       "fileKey": "59mLQlOMiD5w5za6SUcoO5",
       "setNodeId": "83:1647",
       "canvasFingerprint": "v6:3509931486",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:00:35.254Z",
+      "lastSyncedVersionId": "2389961688576685812",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
         "dumpFingerprint": "dumpv1:2896218865",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpVersion": "1.31",
+        "fileVersionId": "2389961688576685812",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/mui/components/circular-progress.json"
     },
     {
       "contractId": "mui.dialog",
       "contractPath": "examples/mui/contracts/dialog.contract.json",
-      "contractHash": "sha256:498709c8ffc98ea8b5d2ac22da003d82e54d57fc4ac5d39e418da3350d07883b",
+      "contractHash": "sha256:aac08da1ce287d512bab818238fe813c9824f37212d49a1b180265fa1c356c70",
       "fileKey": "59mLQlOMiD5w5za6SUcoO5",
       "setNodeId": "21:448",
       "canvasFingerprint": "v6:915053960",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T04:51:10.514Z",
+      "lastSyncedVersionId": "2389961688576685812",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:495750069",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:2148376738",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2389961688576685812",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/mui/components/dialog.json"
     },
     {
@@ -1638,11 +1675,7 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T05:00:33.498Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:1559198692",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/divider.json"
     },
@@ -1656,11 +1689,7 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T05:00:36.655Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:3428439317",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/drawer.json"
     },
@@ -1674,67 +1703,66 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T05:17:13.326Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:3084139766",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/fab.json"
     },
     {
       "contractId": "mui.icon-button",
       "contractPath": "examples/mui/contracts/icon-button.contract.json",
-      "contractHash": "sha256:06b9858a921510144e5809adaf31a91a0a3d3ab2ab2849e5b525cc443c73c58a",
+      "contractHash": "sha256:812bec1dfc5448e3394bc8b5c4f1f35c1b54b3c3f50f1add2abb7152c0bf2ef0",
       "fileKey": "59mLQlOMiD5w5za6SUcoO5",
       "setNodeId": "83:1708",
       "canvasFingerprint": "v6:1946274529",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:00:37.497Z",
+      "lastSyncedVersionId": "2389961688576685812",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:68632039",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:646966808",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2389961688576685812",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/mui/components/icon-button.json"
     },
     {
       "contractId": "mui.input-adornment",
       "contractPath": "examples/mui/contracts/input-adornment.contract.json",
-      "contractHash": "sha256:73f9ebc30b36d116a34116c146119dc805e275f738c680ecce246b908017791f",
+      "contractHash": "sha256:0c641597c8e744a952fb5e05f6e4202f44b3d646faa44130f9d1394b6f19befe",
       "fileKey": "59mLQlOMiD5w5za6SUcoO5",
       "setNodeId": "83:1687",
       "canvasFingerprint": "v6:3114867968",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:00:37.029Z",
+      "lastSyncedVersionId": "2389961688576685812",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2734101850",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:4091473170",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2389961688576685812",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/mui/components/input-adornment.json"
     },
     {
       "contractId": "mui.linear-progress",
       "contractPath": "examples/mui/contracts/linear-progress.contract.json",
-      "contractHash": "sha256:15589f23b2384b58b73fd839755909eea6d1fd2a9219910d3b8134ca4811f9be",
+      "contractHash": "sha256:d808c1d9883e57be70b6f6f8253d9c8403b1dba269ca3988d4f15b6245705f40",
       "fileKey": "59mLQlOMiD5w5za6SUcoO5",
       "setNodeId": "83:1655",
-      "canvasFingerprint": "v6:3801840436",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:00:35.671Z",
-      "direction": "code→canvas",
+      "canvasFingerprint": "v6:2483946288",
+      "lastSyncedVersionId": "2389961688576685812",
+      "lastSyncedAt": "2026-08-23T12:52:35.595Z",
+      "direction": "canvas→code",
       "observed": {
-        "dumpFingerprint": "dumpv1:138171495",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:3931827815",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2389961688576685812",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
-      "note": "receipt parity/receipts/console-loop/mui/components/linear-progress.json"
+      "provenance": "observe",
+      "note": "adopted from live observation 2026-08-23 — restamped by an unrecorded write between 2026-08-09 and 2026-08-21 (Figma version history: TJ Pitre); the dump-v1 projection under the 2026-08-08 mapper (8ac96363) is byte-identical to the 2026-08-08 baseline — content unchanged, stamp adopted (scratchpad REPORT 2026-08-23) (prior: receipt parity/receipts/console-loop/mui/components/linear-progress.json)"
     },
     {
       "contractId": "mui.link",
@@ -1746,31 +1774,28 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T05:04:41.915Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:3780408933",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/link.json"
     },
     {
       "contractId": "mui.menu",
       "contractPath": "examples/mui/contracts/menu.contract.json",
-      "contractHash": "sha256:9efc0e8a2917753d66123781fb868d7175973a1ec0d7b18fb9de6c0a46268354",
+      "contractHash": "sha256:ba9afa5e60dfb236317ec8a3c53f3ecb28d112798ae6abe012a42627612f1d85",
       "fileKey": "59mLQlOMiD5w5za6SUcoO5",
       "setNodeId": "21:451",
       "canvasFingerprint": "v6:226276784",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T04:51:10.514Z",
-      "direction": "code→canvas",
+      "lastSyncedVersionId": "2389961688576685812",
+      "lastSyncedAt": "2026-08-23T12:52:39.983Z",
+      "direction": "canvas→code",
       "observed": {
-        "dumpFingerprint": "dumpv1:1451531493",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:1827025945",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2389961688576685812",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
-      "note": "receipt parity/receipts/console-loop/mui/components/menu.json"
+      "provenance": "observe",
+      "note": "adopted from live observation 2026-08-23 — set carries a v5-era stamp (pre-v6 engine) while the receipt recorded a freshly computed v6 — two instruments, not a write; the dump-v1 projection under the 2026-08-08 mapper equals the 2026-08-08 baseline — content unchanged, re-baselined under grammar 1.31 (prior: receipt parity/receipts/console-loop/mui/components/menu.json)"
     },
     {
       "contractId": "mui.paper",
@@ -1782,11 +1807,7 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T05:00:34.280Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:1549941020",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/paper.json"
     },
@@ -1800,11 +1821,7 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T05:04:42.510Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:465181063",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/radio.json"
     },
@@ -1818,11 +1835,7 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T05:12:50.620Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:3634141290",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/select.json"
     },
@@ -1836,30 +1849,27 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T04:51:10.512Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:635612365",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/slider.json"
     },
     {
       "contractId": "mui.snackbar",
       "contractPath": "examples/mui/contracts/snackbar.contract.json",
-      "contractHash": "sha256:3146d41ef4e06d03d356acd737175aecb86e3bbad97a00670753484886c1b3c7",
+      "contractHash": "sha256:88c5adbe692525cf312e75a16ed22a6e795bb458edca97a4863eee586ce006ac",
       "fileKey": "59mLQlOMiD5w5za6SUcoO5",
       "setNodeId": "84:2140",
       "canvasFingerprint": "v6:4279840767",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:12:51.070Z",
+      "lastSyncedVersionId": "2389961688576685812",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:1794723124",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:2224078824",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2389961688576685812",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/mui/components/snackbar.json"
     },
     {
@@ -1872,31 +1882,28 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T04:51:10.511Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:1573175479",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/switch.json"
     },
     {
       "contractId": "mui.table-pagination",
       "contractPath": "examples/mui/contracts/table-pagination.contract.json",
-      "contractHash": "sha256:146bfc2adcdf56c7e5f5f1b10da5f4ec6983ba05eaa3992332ecf6bd7a2e9d98",
+      "contractHash": "sha256:61a833bbdb98a6b46907129d9dfd09fac3bc3964931decaefc503ca228535b73",
       "fileKey": "59mLQlOMiD5w5za6SUcoO5",
       "setNodeId": "21:627",
-      "canvasFingerprint": "v6:527762080",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T04:51:10.514Z",
-      "direction": "code→canvas",
+      "canvasFingerprint": "v6:2432095718",
+      "lastSyncedVersionId": "2389961688576685812",
+      "lastSyncedAt": "2026-08-23T12:52:35.595Z",
+      "direction": "canvas→code",
       "observed": {
-        "dumpFingerprint": "dumpv1:1908555103",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:2335928335",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2389961688576685812",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
-      "note": "receipt parity/receipts/console-loop/mui/components/table-pagination.json"
+      "provenance": "observe",
+      "note": "adopted from live observation 2026-08-23 — restamped by an unrecorded write between 2026-08-09 and 2026-08-21 (Figma version history: TJ Pitre); the dump-v1 projection under the 2026-08-08 mapper (8ac96363) is byte-identical to the 2026-08-08 baseline — content unchanged, stamp adopted (scratchpad REPORT 2026-08-23) (prior: receipt parity/receipts/console-loop/mui/components/table-pagination.json)"
     },
     {
       "contractId": "mui.table",
@@ -1908,11 +1915,7 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T04:51:10.515Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:1275646288",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/table.json"
     },
@@ -1926,11 +1929,7 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T04:51:10.512Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:2373902012",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/tabs.json"
     },
@@ -1944,30 +1943,27 @@
       "lastSyncedVersionId": null,
       "lastSyncedAt": "2026-08-06T05:26:56.332Z",
       "direction": "code→canvas",
-      "observed": {
-        "dumpFingerprint": "dumpv1:3699061567",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
-      },
+      "observed": null,
       "provenance": "seeded-from-receipts",
       "note": "receipt parity/receipts/console-loop/mui/components/text-field.json"
     },
     {
       "contractId": "mui.tooltip",
       "contractPath": "examples/mui/contracts/tooltip.contract.json",
-      "contractHash": "sha256:180012c2f6315b158f85de72c1564fc028398eca8524d5ae3bffaab2d5b30b08",
+      "contractHash": "sha256:13d7e5e8ac14c7ffe2547d7c69e47b99de55a27f0d3b537c4ed3381481a0276f",
       "fileKey": "59mLQlOMiD5w5za6SUcoO5",
       "setNodeId": "21:810",
       "canvasFingerprint": "v6:1221797663",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T04:51:10.514Z",
+      "lastSyncedVersionId": "2389961688576685812",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:2853288222",
-        "fileVersionId": "2384477865735882405",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:2057400026",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2389961688576685812",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/mui/components/tooltip.json"
     },
     {
@@ -2113,19 +2109,20 @@
     {
       "contractId": "polaris.text",
       "contractPath": "examples/polaris/contracts/text.contract.json",
-      "contractHash": "sha256:1e561e02a7d84ea2b5b4de238b9eb5193be654b311b4029ff1aeced5c6c4e306",
+      "contractHash": "sha256:ed8fbc6f63789757ec73c1479fe72470658685077c1b32db6e4401d03fe146ff",
       "fileKey": "GnQnjSNBXtgtd2Ht0Hs1C8",
       "setNodeId": "1:10480",
       "canvasFingerprint": "v6:3918753726",
-      "lastSyncedVersionId": null,
-      "lastSyncedAt": "2026-08-06T05:47:38.221Z",
+      "lastSyncedVersionId": "2390537264651373038",
+      "lastSyncedAt": "2026-08-23T12:52:13.079Z",
       "direction": "code→canvas",
       "observed": {
-        "dumpFingerprint": "dumpv1:922913781",
-        "fileVersionId": "2385311290720626690",
-        "observedAt": "2026-08-08T13:51:42.601Z"
+        "dumpFingerprint": "dumpv1:1115150788",
+        "dumpVersion": "1.31",
+        "fileVersionId": "2390537264651373038",
+        "observedAt": "2026-08-23T12:52:39.983Z"
       },
-      "provenance": "seeded-from-receipts",
+      "provenance": "observe",
       "note": "receipt parity/receipts/console-loop/polaris/components/text.json"
     },
     {

--- a/sync/ledger.ts
+++ b/sync/ledger.ts
@@ -36,6 +36,16 @@
  *                        byte-compatible with the plugin dump). A designer
  *                        edit does NOT restamp v6, so THIS is what catches
  *                        it once a baseline exists.
+ *   observed.dumpVersion — the dump GRAMMAR (extract/figma/rest/map.ts
+ *                        REST_DUMP_VERSION) the baseline was computed under.
+ *                        Baselines compare only WITHIN a grammar: when the
+ *                        mapper moves, every baseline's bytes move with it and
+ *                        the difference is the instrument, not the canvas.
+ *                        Measured 2026-08-23: the 1.5 → 1.31 move turned 87
+ *                        untouched sets into "designer edit" rows on six
+ *                        scheduled spine runs. An untagged or foreign-grammar
+ *                        baseline is named INCOMPARABLE and never counts as
+ *                        canvas evidence.
  */
 import { canonicalJson, revisionOf } from '../core/contract-provenance.js';
 
@@ -56,6 +66,10 @@ export type RecordProvenance =
 export interface ObservationBaseline {
   /** `dumpv1:<djb2>` over canonicalJson of the set's dump-v1 projection. */
   dumpFingerprint: string;
+  /** The dump grammar (REST_DUMP_VERSION) that produced `dumpFingerprint`.
+   *  Absent on baselines recorded before 2026-08-23 — those are incomparable
+   *  with any current observation and must be re-recorded. */
+  dumpVersion?: string;
   /** Figma REST file `version` at observation time (null when the
    *  observation came from a fixture that carries none). */
   fileVersionId: string | null;
@@ -173,8 +187,11 @@ export function validateRecord(raw: unknown, where: string): LedgerRecord {
       refuse(`${where}.observed.dumpFingerprint`, 'must be a "dumpv1:<digits>" fingerprint');
     if (typeof ob.observedAt !== 'string' || Number.isNaN(Date.parse(ob.observedAt)))
       refuse(`${where}.observed.observedAt`, 'must be an ISO-8601 timestamp');
+    if (ob.dumpVersion !== undefined && (typeof ob.dumpVersion !== 'string' || ob.dumpVersion.length === 0))
+      refuse(`${where}.observed.dumpVersion`, 'must be a non-empty string when present');
     observed = {
       dumpFingerprint: ob.dumpFingerprint,
+      ...(typeof ob.dumpVersion === 'string' ? { dumpVersion: ob.dumpVersion } : {}),
       fileVersionId: optString(ob.fileVersionId, `${where}.observed.fileVersionId`),
       observedAt: ob.observedAt,
     };
@@ -403,10 +420,22 @@ export interface SetObservation {
   stamp: string | null;
   /** Observation-domain fingerprint over the set's dump-v1 projection. */
   dumpFingerprint: string;
+  /** The dump grammar that produced `dumpFingerprint` (REST_DUMP_VERSION). */
+  dumpVersion: string;
   fileVersionId: string | null;
 }
 
 export type CanvasEvidence = 'baseline' | 'stamp' | 'version' | 'none' | 'unobserved';
+
+/** A recorded baseline is comparable with an observation only when both were
+ *  computed under the SAME dump grammar. Untagged (pre-2026-08-23) baselines
+ *  are never comparable — refuse over guess. */
+export function baselineComparableWith(
+  observed: ObservationBaseline | null,
+  obs: Pick<SetObservation, 'dumpVersion'>,
+): boolean {
+  return observed !== null && observed.dumpVersion !== undefined && observed.dumpVersion === obs.dumpVersion;
+}
 
 export interface DriftRow {
   key: string;
@@ -457,7 +486,17 @@ export function classifyRecord(
       );
     }
     const stampChanged = stampComparable && obs.stamp !== record.canvasFingerprint;
-    const baselineComparable = record.observed !== null;
+    // Baselines compare only WITHIN a dump grammar (see the header). A
+    // baseline the current mapper cannot reproduce is named and ignored —
+    // it is evidence about the instrument, never about the canvas.
+    const baselineComparable = baselineComparableWith(record.observed, obs);
+    if (record.observed !== null && !baselineComparable) {
+      notes.push(
+        `observation baseline ${record.observed.dumpFingerprint} was recorded under dump grammar ` +
+          `${record.observed.dumpVersion ?? '(untagged)'} and the mapper now speaks ${obs.dumpVersion} — ` +
+          'incomparable (the instrument moved, not the canvas); re-record it with `sync observe --update`',
+      );
+    }
     const baselineChanged =
       baselineComparable && obs.dumpFingerprint !== record.observed!.dumpFingerprint;
     if (stampChanged) {
@@ -480,7 +519,9 @@ export function classifyRecord(
       // baseline.
       canvasChanged = false;
       canvasEvidence = 'stamp';
-      notes.push('stamp matches; no observation baseline yet (run observe --update to record one)');
+      if (record.observed === null)
+        notes.push('stamp matches; no observation baseline yet (run observe --update to record one)');
+      else notes.push('stamp matches; the baseline above is incomparable until re-recorded');
     } else if (
       record.lastSyncedVersionId !== null &&
       obs.fileVersionId !== null &&

--- a/sync/observe.ts
+++ b/sync/observe.ts
@@ -14,7 +14,12 @@
  * the gate-shaped offline path, sync:ledger:check) and over the live API
  * (fetchObservation, FIGMA_TOKEN). Pure except fetchObservation.
  */
-import { mapRestToDump, type RestNode, type RestNodesResponse } from '../extract/figma/rest/map.js';
+import {
+  mapRestToDump,
+  REST_DUMP_VERSION,
+  type RestNode,
+  type RestNodesResponse,
+} from '../extract/figma/rest/map.js';
 import { FIGMA_API_BASE, type FetchLike } from '../extract/figma/rest/fetch.js';
 import { dumpFingerprint, type SetObservation } from './ledger.js';
 
@@ -56,6 +61,7 @@ export function observationsFromRestNodes(
       setName: doc.name,
       stamp: dsMarker(doc, 'canvasFingerprint'),
       dumpFingerprint: dumpFingerprint(entryDump),
+      dumpVersion: REST_DUMP_VERSION,
       fileVersionId,
     });
   }

--- a/sync/pull.ts
+++ b/sync/pull.ts
@@ -380,7 +380,7 @@ export function pullRecord(input: PullInput): PullOutcome {
     lastSyncedVersionId: fileVersionId,
     direction: 'canvas→code',
     observed: observation
-      ? { dumpFingerprint: observation.dumpFingerprint, fileVersionId }
+      ? { dumpFingerprint: observation.dumpFingerprint, dumpVersion: observation.dumpVersion, fileVersionId }
       : null,
   };
   const counts = findingCounts(findings);

--- a/sync/receipts/2026-08-23-spine-reconciliation.md
+++ b/sync/receipts/2026-08-23-spine-reconciliation.md
@@ -1,0 +1,77 @@
+<!-- Landed 2026-08-23 on branch sync/spine-grammar-aware. This is the investigation report for the
+six red scheduled sync-spine runs, committed so the per-row evidence is in the repo and not only in a
+session scratchpad. Two notes on what this branch did and did NOT do with it:
+
+1. The ledger reconciliation landed here covers ONLY classes A / A' / B1 (69 rows: 64 re-pinned, 5
+   adopted with a note). Classes B2 (50), B3 (5), C (1), D1 (1), D2 (2) are left exactly as the spine
+   reports them — 55 conflict + 4 code-ahead — because each is a decision for the owner, not the
+   instrument. Their pre-2026-08-23 baselines (recorded under dump grammar 1.5, untagged) were DROPPED
+   by name by the re-baseline because `sync:ledger:check` rule 5 refuses a ledger whose baselines do
+   not speak the mapper's grammar (1.31); the only record that the two D2 canvases (mui.fab, mui.link)
+   actually moved is the evidence in the D2 row below.
+2. The "Exit semantics verdict" section proposes mapping spine exit 1 (drift) to a green run with a
+   warning. That change was NOT landed: it reverses the 2026-08-08 decision that a red scheduled run IS
+   the drift signal, which is the owner's to make. The workflow keeps its exit behaviour; the only
+   yml change on this branch copies SPINE.md into the job summary before re-raising the spine's own
+   exit code. Re-verified live on this branch (read-only, plan mode): 69 in-sync / 55 conflict / 4
+   code-ahead.
+-->
+
+# sync-spine: why six scheduled runs were red, classified — 2026-08-23
+
+Worktree: origin/main fa88dbf1. Figma: REST GET only (nodes + versions); no write, no branch, no PR.
+Run examined: 32634036683 (fa88dbf1, 10:32Z) + first red 32602697045 (4cfbb699, 08-22 22:31Z) + latest 32639783128. All three files' REST `version` were IDENTICAL in both red runs (GnQnj 2390537264651373038 · BMjUA 2388438498796415748 · 59mLQ 2389961688576685812) — the canvas did not move between them, yet 15 rows went in-sync → "designer edit" and every baseline fingerprint changed. That is the instrument.
+
+## What the ledger compares (answer to 1a)
+- Code half: `contractHashOf(contracts/*.json on disk)` vs `ledger.contractHash`. Committed `.figma.js` re-emits, specHash and receipt stamps play NO part.
+- Canvas half: the v6 stamp read over REST (`plugin_data=shared`) vs `ledger.canvasFingerprint`; then `dumpv1` of the REST dump-v1 projection vs `ledger.observed.dumpFingerprint`. Never canvas-vs-committed-script.
+
+## Root causes (three, all repo-side or session-side; zero third-party designer edits)
+1. **Dump grammar moved, baselines did not** — `extract/figma/rest/map.ts` went dumpVersion 1.5 → 1.31 (9d65808e, 0dc0811c, cda65c2b on 08-22; plus an unbumped 21-line change on 08-15). All 87 baselines were recorded 08-08 under 1.5. Proof: re-dumping today's canvas (raw in scratchpad/raw/) with the 08-08 mapper (`git show 8ac96363:extract/figma/rest/map.ts`) reproduces the 08-08 baseline byte-for-byte for **66** of 87 baseline rows → those canvases are unchanged; the "designer edit" note was false. Includes the named rows ds.code, ds.table-cell, ds.toast (their PR bundles' "mismatches" are token-name inversions only: `{color.surface.sunken}` vs `{imported.code.root.background-color}`).
+2. **Contract bytes moved by bookkeeping** — schema 17 codemod dbeb3575 (104 records: v16 `anchors`/figma-only fields → `bindings.*`), anchor re-points cc6a2976/2d0ffef1 (16 records, `bindings.*.anchors` only). Verified by applying `migrateDocumentToV17` to the 8ac96363 bytes: 120 records differ from HEAD by nothing else. This is why 32602697045 had "12 conflict, 85 canvas-ahead, 21 in-sync" and the next run "119 conflict, 9 code-ahead". 8 records changed semantically (astryx.banner, flowbite.alert, flowbite.toggleswitch, mui.accordion, mui.avatar, mui.fab, mui.link, mui.slider).
+3. **Unrecorded canvas writes** — 58 sets carry a v6 stamp that appears nowhere in the repo (no receipt, no ledger). Figma version history: every version since 08-09 is by "TJ Pitre" (plugin/console-loop sessions 08-09, 10, 11, 12, 16, 17, 20, 21) + one "Figma" autosave 08-22; no other user. Receipts under parity/receipts/console-loop still carry the 08-06/08-08 v6 for all 128 rows; nothing in the repo calls `sync record --from-receipt` (README's "the verb the generate loops call" is not wired).
+
+## Classified table (every non-in-sync row of run 32634036683)
+| class | n | rows | evidence | reconciliation | Figma write? |
+|---|---|---|---|---|---|
+| **A** instrument-only (cause 1+2) | 64 | all `ds.*` except banner/card/token; altitude.badge/chip/divider/iconclose/link; carbon.button; flowbite.badge; polaris.text; mui.autocomplete/breadcrumbs/card/chip/circular-progress/dialog/icon-button/input-adornment/snackbar/tooltip | stamp == ledger; 08-08 mapper reproduces baseline (or no baseline); contract delta = codemod/anchors only | `sync observe --repin <ids>` (new verb; refuses unless stamp matches) — **done in patch** | no |
+| **A'** two instruments (v5 stamp) | 2 | mui.button, mui.menu | set carries v5 stamp, receipt recorded v6; 08-08 mapper == baseline | `--adopt` with note (v5 cannot be recorded; baseline is the evidence) — **done** | no |
+| **B1** restamp-only write, content identical | 3 | flowbite.card, mui.linear-progress, mui.table-pagination | stamp Δ; 08-08 mapper == baseline | `--adopt` with note — **done** | no |
+| **B2** unrecorded session write, code delta bookkeeping-only | 50 | altitude.button,altitude.heading,astryx.badge,astryx.button,astryx.card,astryx.checkbox-input,astryx.dropdown-menu-item,astryx.dropdown-menu,astryx.progress-bar,astryx.slider,astryx.switch,astryx.text-input,astryx.toast,astryx.token,carbon.accordion,carbon.checkbox,carbon.iconbutton,carbon.inlinenotification,carbon.modal,carbon.tabs,carbon.tag,carbon.textinput,carbon.toggle,flowbite.button,polaris.avatar,polaris.badge,polaris.banner,polaris.button,polaris.checkbox,polaris.progress-bar,polaris.radio-button,polaris.spinner,polaris.tag,polaris.text-field,polaris.thumbnail,ds.banner,ds.card,ds.token,mui.alert,mui.badge,mui.checkbox,mui.divider,mui.drawer,mui.paper,mui.radio,mui.select,mui.switch,mui.table,mui.tabs,mui.text-field | stamp Δ, value in no receipt; commits 08-09..17 say "rebuilt/flips to pass ON THE CANVAS" | TJ: `npm run sync:observe -- --adopt <ids> --note "…"` if the canvas is the truth (repo-side, no write) — or re-apply from code via plugin (**Figma write**) | his call |
+| **B3** unrecorded write AND semantic code change | 5 | astryx.banner,flowbite.alert,mui.accordion,mui.avatar,mui.slider | as B2 + anatomy/props/events changed in contract after the write | true conflict: review the bundle in the artifact; then `--adopt` or publish+apply (**write**) | his call |
+| **C** genuine code-ahead | 1 | flowbite.toggleswitch | stamp == ledger, 08-08 mapper == baseline, contract semantics/anatomy/events changed (968958cd) | canvas is behind: publish+apply (**Figma write**) | yes |
+| **D1** stamp stripped | 1 | altitude.avatar | set carries NO `ds_contracts/canvasFingerprint`; 08-08 mapper == baseline (content unchanged) | restamp via plugin (**write**) then `--adopt`; now reports "no canvas evidence" honestly | yes |
+| **D2** canvas moved w/o restamp AND semantic code change (session hand-edit) | 2 | mui.fab, mui.link | stamp == ledger; 08-08 mapper ≠ baseline (real canvas change, e.g. mui.link root layout HORIZONTAL/CENTER → VERTICAL/MIN); contract anatomy changed 16889547 | true conflict — TJ. NOTE: their 1.5 baselines were dropped by the re-baseline (incomparable under 1.31); this report is now the only record that those two canvases moved | his call |
+
+(Per-row evidence: scratchpad/classes.txt, redump-verdicts.txt, code-half-classes.txt.)
+
+## After the patch (live, read-only, verified)
+`sync observe`: **69 in-sync, 55 conflict (50 B2 + 5 B3), 4 code-ahead (C, D1, D2×2)** — every remaining row is a real decision for TJ; none is the instrument.
+Ledger delta: 69 hashes re-pinned, 3 stamps adopted, 69 baselines re-recorded under grammar 1.31, 23 incomparable (1.5, untagged) baselines dropped by name.
+
+## Spine logic fixes in spine.patch (the misclassification was real)
+- `ledger.ts`: `observed.dumpVersion`; `SetObservation.dumpVersion`; `baselineComparableWith` — baselines compare only within a grammar; foreign/untagged → "incomparable (the instrument moved, not the canvas)", never canvas evidence. `map.ts` exports `REST_DUMP_VERSION`.
+- `cli.ts observe`: `--repin id[,…]` (refuses unless stamp == ledger), `--adopt id[,…] [--note]` (explicit ids, never all), `--update` drops incomparable baselines loudly on rows it cannot re-baseline.
+- `ledger-check.ts` rule 5: a committed baseline not speaking the mapper's grammar refuses in the FAST lane with the re-baseline command — a grammar bump must ship with its live re-baseline, not surface as designer edits on the cron 2 h later.
+- `spine.ts` PR body "After merging": `--update` could never re-baseline a merged proposal (row is not in-sync) → now `--adopt <id>`.
+- evals `sync-ledger-lockfile`: 4 new red assertions (foreign grammar → in-sync by stamp with the instrument named; untagged → named; moved stamp under foreign grammar → still canvas-ahead). Fixture ledger baselines tagged.
+- docs/23 §B.14 correction: "the REST route cannot read shared plugin data" is false (this run read 128 stamps over REST).
+
+## Exit semantics verdict (3) — NOT LANDED; owner decision (see header note 2)
+Header said "a red run IS the drift signal". Six reds, one cause, zero actionable-by-merge, and spine exit 1 (drift, bundles produced) was indistinguishable from exit 2 (spine crashed). **Revised in the patch:** spine exit 1 → green + `::warning` + drift table in `$GITHUB_STEP_SUMMARY` + artifact + output `drift=true`; exit 2 → the lane's only red; exit 0 → notice. Script exit codes unchanged (eval-pinned). README, workflow header, lane-coverage text updated. This reverses the 08-08 decision — say so if you disagree; it is one `case` block.
+
+## Verification on the patched tree
+- `npm run sync:ledger:check` → 128 ok, 123 receipt-citing verified (5 adopted rows re-noted), 69 baselines speak 1.31.
+- `npx tsx evals/run.ts --only sync-spine,channel-round-trip,sync` → 4/4: channel-round-trip, sync-ledger-lockfile, sync-spine-drift, pending-first-sync-not-drift.
+- `npx tsc --noEmit` 0 · `npm run lint` 0 · `npm run format:check` clean.
+- Live `sync:spine --run-id local-verify` (read-only): Totals 55 conflict, 4 code-ahead, 69 in-sync; exit 1.
+
+## Commands for TJ (repo-side unless marked WRITE)
+```
+# B2 — accept the canvas as truth for the 08-09..21 session writes (no Figma write):
+npm run sync:observe -- --adopt altitude.button,altitude.heading,astryx.badge,astryx.button,astryx.card,astryx.checkbox-input,astryx.dropdown-menu-item,astryx.dropdown-menu,astryx.progress-bar,astryx.slider,astryx.switch,astryx.text-input,astryx.toast,astryx.token,carbon.accordion,carbon.checkbox,carbon.iconbutton,carbon.inlinenotification,carbon.modal,carbon.tabs,carbon.tag,carbon.textinput,carbon.toggle,flowbite.button,polaris.avatar,polaris.badge,polaris.banner,polaris.button,polaris.checkbox,polaris.progress-bar,polaris.radio-button,polaris.spinner,polaris.tag,polaris.text-field,polaris.thumbnail,ds.banner,ds.card,ds.token,mui.alert,mui.badge,mui.checkbox,mui.divider,mui.drawer,mui.paper,mui.radio,mui.select,mui.switch,mui.table,mui.tabs,mui.text-field --note "session applies 2026-08-09..21, receipts never re-recorded"
+# B3 / D2 — review sync/out bundles first (artifact sync-spine-32634036683), then --adopt or publish+apply (WRITE)
+# C  — flowbite.toggleswitch: publish+apply through the plugin (WRITE), then npm run sync:observe -- --adopt flowbite.toggleswitch
+# D1 — altitude.avatar: restamp via plugin (WRITE), then --adopt
+```
+Process hole to close separately: nothing records a plugin apply / console-loop rebuild into the ledger (README's "generate loops call sync record" is unwired) — every B row is that hole.

--- a/sync/spine.ts
+++ b/sync/spine.ts
@@ -241,8 +241,9 @@ function buildPrPlan(
     '',
     '## After merging',
     '',
-    '1. Re-baseline the sync ledger so the next observation records the adoption: ' +
-      '`npm run sync:observe -- --update` (or `ds-contracts figma receive --apply` when landing via the envelope path).',
+    `1. Record the adoption in the sync ledger: \`npm run sync:observe -- --adopt ${record.contractId}\` ` +
+      '(the canvas is the truth for this row: current contract hash + observed stamp + a fresh baseline, direction canvas→code). ' +
+      'A plain `--update` cannot do this — the merged contract hash differs from the ledger, so the row is not in-sync and `--update` skips it.',
     '2. Regenerate code surfaces from the adopted contract (`ds-contracts generate …`).',
     '',
     '_Opened by the sync spine (sync/spine.ts). The fingerprint marker at the top is how the spine avoids ' +


### PR DESCRIPTION
## What this is

Six scheduled `sync-spine` runs (2026-08-22/23) were red for one cause: the REST dump grammar moved 1.5 → 1.31 on 08-22 while every observation baseline in `sync/ledger.json` was recorded on 08-08 under 1.5, so untouched canvases reported as designer edits; the schema-17 codemod + anchor re-points moved contract bytes on 120 records with no semantic change on 112 of them. Re-dumping today's canvas with the 08-08 mapper reproduces the 08-08 baseline byte-for-byte on 66 rows. The full investigation, with the per-row classified table, is committed as `sync/receipts/2026-08-23-spine-reconciliation.md`.

## Spine changes

- `sync/ledger.ts`: `observed.dumpVersion` per row; baselines compare only within a grammar; a foreign/untagged baseline is "incomparable (the instrument moved, not the canvas)", never canvas evidence. `extract/figma/rest/map.ts` exports `REST_DUMP_VERSION`.
- `sync/cli.ts observe`: `--repin id[,…]` (refuses unless the observed stamp equals the ledger's), `--adopt id[,…] [--note]` (explicit ids only, never all); `--update` drops incomparable baselines loudly on rows it cannot re-baseline.
- `sync/ledger-check.ts` rule 5 (fast lane, rides the existing `sync:ledger:check`): a committed baseline that does not speak the mapper's grammar refuses with the re-baseline command — a grammar bump ships with its live re-baseline, not as "designer edits" on the cron two hours later.
- `sync/spine.ts` PR body "After merging": `--adopt <id>` (a plain `--update` can never re-baseline a merged proposal).
- evals `sync-ledger-lockfile`: four new red assertions; fixture baselines tagged.
- docs/23 §B.14 corrected: the REST route does read shared plugin data (128 stamps read over `/nodes?plugin_data=shared`).
- `.github/workflows/sync-spine.yml`: copies `SPINE.md` into the job summary, then re-raises the spine's own exit code. **Exit semantics unchanged** (see below).

## Ledger reconciliation — instrument-only rows only

Classes A / A' / B1 (69 rows): 64 re-pinned (`--repin`, stamp provably equal to the ledger's), 5 adopted with a note (A' two-instrument v5 stamps: mui.button, mui.menu; B1 restamp-only writes with identical content: flowbite.card, mui.linear-progress, mui.table-pagination). 69 baselines re-recorded under grammar 1.31; 23 incomparable (1.5, untagged) baselines dropped by name.

Live, read-only, plan mode (no PR, no Figma write) on this branch: **69 in-sync / 55 conflict / 4 code-ahead**.

## The 59 rows left red — decisions for the owner, not adopted here

| class | n | rows | what it is | your options |
|---|---|---|---|---|
| **B2** | 50 | altitude.button, altitude.heading, astryx.{badge,button,card,checkbox-input,dropdown-menu-item,dropdown-menu,progress-bar,slider,switch,text-input,toast,token}, carbon.{accordion,checkbox,iconbutton,inlinenotification,modal,tabs,tag,textinput,toggle}, flowbite.button, polaris.{avatar,badge,banner,button,checkbox,progress-bar,radio-button,spinner,tag,text-field,thumbnail}, ds.{banner,card,token}, mui.{alert,badge,checkbox,divider,drawer,paper,radio,select,switch,table,tabs,text-field} | unrecorded session write (08-09..21 plugin/console-loop applies, receipts never re-recorded); code delta is bookkeeping-only | `npm run sync:observe -- --adopt <ids> --note "…"` if the canvas is the truth (repo-side), or re-apply from code via the plugin (Figma write) |
| **B3** | 5 | astryx.banner, flowbite.alert, mui.accordion, mui.avatar, mui.slider | unrecorded write AND semantic contract change | true conflict: review the bundle, then `--adopt` or publish+apply (write) |
| **C** | 1 | flowbite.toggleswitch | genuine code-ahead (968958cd) | publish+apply through the plugin (write), then `--adopt` |
| **D1** | 1 | altitude.avatar | set carries no `ds_contracts/canvasFingerprint` stamp; content unchanged | restamp via plugin (write), then `--adopt` |
| **D2** | 2 | mui.fab, mui.link | canvas moved without restamp (e.g. mui.link root layout HORIZONTAL/CENTER → VERTICAL/MIN) AND contract anatomy changed (16889547) | true conflict. Their 1.5 baselines were dropped as incomparable; the receipt is now the only record that these two canvases moved |

Per-row commands are in the receipt's "Commands for TJ" section.

## Policy question not decided here: exit semantics of the scheduled lane

The investigation proposed mapping spine exit 1 (drift, bundles produced) to a green run with a `::warning`, the drift table in the summary and `drift=true` output, leaving exit 2 (the spine could not run) as the lane's only red — on the grounds that six reds with one repo-side cause were indistinguishable from a designer edit or a crash. That reverses the 2026-08-08 decision that "a red scheduled run IS the drift signal", so it is **not** in this PR: the lane still goes red on drift. What did land is the separable half (the drift table in the job summary; the artifact upload already existed). If you want the reversal, it is one `case` block in `.github/workflows/sync-spine.yml` plus the matching text in `sync/README.md` and `.github/scripts/lane-coverage.ts`.

Process hole to close separately: nothing records a plugin apply / console-loop rebuild into the ledger (README's "generate loops call `sync record`" is unwired) — every B row is that hole.

## Gates (all exit 0 on this branch)

tsc · lint · format:check · ci:lanes · docs:check · `sync:ledger:check` (128 ok, 123 receipt-citing verified, 69 baselines speak 1.31) · `evals --only sync-spine,channel-round-trip,sync,pending-first-sync` 4/4 · maintain · live read-only `sync:spine` (69/55/4) · full suite recorded in `evals/results.json`.
