### PR TITLE
A stated channel is one carrier — the offline re-fuse no longer mints a px token beside a G8 fit-content literal (polaris Tag)

### DIFF
--- a/docs/23-known-limitations.md
+++ b/docs/23-known-limitations.md
@@ -1149,21 +1149,36 @@ named a row in [docs/26](26-v1-definition.md). Both were closed on
 carries what was actually wrong (not quite what this row said), the fix, and
 the lanes that now pin each.
 
-## B.29 polaris Tag no longer re-fuses offline: an ambiguous `width` on the link part
+## B.29 polaris Tag no longer re-fuses offline: an ambiguous `width` on the link part — CLOSED, see §D.33
 
-Found 2026-08-23 by the repaired drift instrument ([§D.32](#d32-the-two-acceptance-rows-that-were-red-on-the-commit-itself--closed)),
-not by a human. `extract/computed/regate.ts` replaying polaris Tag's committed
-captured truth through the engine at `d5b5b0b1` produces an enriched contract
-whose `link` part carries `width` as BOTH a token binding
-(`{imported.shared.size-59-9219}`) and a literal (`fit-content`); the contract
-validator refuses that by name ("ambiguous — keep ONE of tokens.width /
-literals.width"). The same component fused on 2026-08-09 (offline 80.521 %,
-12,896 cells). The refusal is PINNED in `extract/computed/regate-baseline.json`
-(`refused`), so the re-measure goes red if it changes or the component fuses
-again without a re-record; the committed harness scorecard (capture-time
-engine) is untouched. **Not fixed here** — the fix is in fusion (which of the
-two spellings the mint should keep for a `fit-content` width), and it owes a
-gapCause when it lands.
+*Closed 2026-08-23 (r12). The refusal was real; the diagnosis in this row
+("the fix is in fusion — which of the two spellings the mint should keep")
+was half right: the promotion had already chosen (`literals.width =
+"fit-content"`, G8), and the mint re-minted the channel because the door
+that makes a stated channel bound territory did not see `width` at all. The
+register entry [§D.33](#d33-polaris-tag-refused-to-re-fuse-the-mint-re-minted-a-channel-the-promotion-had-already-stated--closed)
+carries the cause, the rule, the receipt and the re-recorded row. The number
+is kept so the files that cite §B.29 still resolve.*
+
+## B.30 `promote-floor` does not reproduce the committed polaris contracts
+
+Found 2026-08-23 while re-running the documented polaris recipe
+([examples/polaris/PROVENANCE.md](../examples/polaris/PROVENANCE.md)) on
+`537022b0` to prove it byte-neutral. `npx tsx examples/polaris/scripts/promote-floor.ts`
+rewrites 8 of the 12 committed contracts (avatar, button, checkbox,
+progress-bar, radio-button, spinner, text-field, thumbnail) and the minted
+tree; the diffs are hand-curated facts that live only in the committed
+files, not in the authored-facts ledger the promoter reads — avatar's
+`initials` default `"TP"` and `withInitials` default `true` (with the
+receipt-citing descriptions that explain them) are the clearest. The
+regenerate step then re-emits 20 figma scripts and the bundle from the
+rewritten contracts. `generate.ts --check` is green on the committed tree
+because it re-emits from the committed contracts; the promote step before
+it is the one that does not round-trip. Not fixed here — the fix is to move
+the curation into `ds-library.json`'s authored rows (or a receipt that says
+the committed contract is post-promotion curated), and it owes a gate that
+runs the promote step, not just the emit step. The tree was restored from
+git after the measurement; nothing from that run is in this round's patch.
 
 ---
 
@@ -2864,3 +2879,104 @@ family `diagnose-*` is green.
 diagnose`. full: `extract:computed:drift:remeasure`. The `diagnose` step goes
 red by design when the snapshot passes 14 days; the fix is the one REST
 command above. Commit `a46593b6`.
+
+## D.33 polaris Tag refused to re-fuse: the mint re-minted a channel the promotion had already stated — CLOSED
+
+**Was §B.29.** Found by the repaired drift instrument on 2026-08-23
+([§D.32](#d32-the-two-acceptance-rows-that-were-red-on-the-commit-itself--closed)):
+`extract/computed/regate.ts` replaying polaris Tag's committed captured truth
+through the current engine produced a `link` part carrying `width` as BOTH
+`tokens.width = {imported.shared.size-59-9219}` and `literals.width =
+"fit-content"`, and `validateContract` refused the ambiguity by name. What
+re-measurement found, against what §B.29 said:
+
+- *Not the promoter, and not the committed artifacts.* `packages/cli/src/promote.ts`
+  reads `resolved.contract.json`; neither it nor the committed
+  `enriched.contract.json` (capture-time engine, 2026-07-29) nor the promoted
+  `examples/polaris/contracts/tag.contract.json` ever carried the double
+  spelling — the committed `link` carries `tokens.width` alone (and the grid
+  tracks as a `grid-template-columns` token, the pre-G1–G5 spelling). The
+  double spelling existed only in the OFFLINE re-fuse through the current
+  engine.
+- *Not fusion choosing between two spellings of one fact.* The promotion had
+  already decided. `anatomy.ts gridDefiniteAxisLiterals` (G8, `e16b6f6c`,
+  2026-08-08) runs BEFORE the mint and states `literals.width = "fit-content"`
+  on a display:grid part whose used box equals its intrinsic track sum
+  (59.9219 px = the one fixed column) — the box IS its content, the canvas
+  hugs it. The mint then minted the same used box as a fixed token beside
+  it.
+- *The cause was a silent hole in the "already carried" door.*
+  `extract/computed/fuse.ts carriedChannels` — "channels the contract
+  carries for a part — BOUND territory; the mint pass never re-mints them"
+  — mapped each token / per-prop / literal / state channel through
+  `CHANNEL_TO_COMPUTED` with `?? []`. That registry spells shorthands and the
+  lifted longhands, not every bounded channel: 45 token/literal channels
+  (`width`, `height`, `top`/`right`/`bottom`/`left`, the four paddings and
+  margins, `opacity`, `z-index`, `flex-grow`, the grid placement longhands,
+  …) resolved to NOTHING, so a part that already stated one of them was
+  re-minted as if it stated nothing. The `declared` branch of the same
+  function already fell back to the channel's own name. Measured blast
+  radius: no capture seed in any of the eight configs carries a token,
+  literal, per-prop map or state on any of the 45 (0 hits); the only
+  pre-mint writer on them is G8, and the 2026-08-23 full re-measure refused
+  exactly one component. The polaris re-record then showed the one other
+  effect, and it is a removal of dead weight: avatar, progressbar and
+  thumbnail carry root `width`/`height` per size as a REVIEWED
+  `literalsByProp` entry, and the old door still minted those per-size
+  leaves into the minted tree (5 + 3 + 4 leaves) only for the
+  `tokensByProp conflict avoided` merge rule to keep them out of the
+  contract — orphan leaves. They are no longer minted; the re-fused
+  contracts are deep-compared HEAD engine vs fixed — avatar and thumbnail
+  identical, progressbar identical in every fact (its root `tokensByProp`
+  keeps the seed's single-entry object spelling instead of being
+  re-normalised to a one-element array, because no per-axis addition
+  touches the root any more; both spellings read through
+  `tokensByPropEntries`) — every percentage is unchanged, and the three
+  tracked `regate.scorecard.json` files move only in
+  `mintedLeaves`/`baseBindings`. No other library states
+  a channel on the list before the mint, so the rest of the corpus is
+  untouched.
+
+**The rule (one).** A channel the promoted contract already states —
+whichever field states it — is one carrier; the mint never re-mints it.
+`carriedChannels` now falls back to the channel's own name in every branch.
+For G8 this means the literal wins: `fit-content` is a sizing MODE (HUG)
+that a fixed px token cannot spell, and a fixed token beside a hugging axis
+would pin the canvas to the base plane's text width; the computed px is the
+literal's base-plane consequence, not a second fact. This is the same
+verdict the canvas→code proposer already gives (`core/exact-proposal-check.ts`
+#41: "height carries as the G8 literal fit-content only — no minted root
+height beside it"), so the two directions now agree. The not-minted value is
+receipted by name in the extension (`carried-axis-not-reminted: link.width —
+the promotion states it as literals.width "fit-content" (grid-axis-definite,
+G8); the computed 59.9219px is that literal's base-plane used box, not a
+second fact, and is NOT minted beside it`). Where a G8 px literal (used box
+larger than the track sum) is stated and the used box varies along a
+defaultless axis, the existing `carried-channel-reminted` door still re-mints
+the set planes; variation along a defaulted axis stays with the literal, the
+same as every other reviewed carriage — named, not hidden.
+
+**Numbers.** polaris Tag re-fuses: offline 81.551 % (6140/7529 cells, 0
+unresolved refs) against the committed harness 81.016 % (5996/7401); 128
+cells added and 144 more equal, so 16 previously-compared cells changed
+verdict to EQUAL — the hugging link. The baseline row drops `refused` and
+names the gap; the tracked `out/tag/regate.scorecard.json` is the re-record.
+The committed capture artifacts and the promoted Tag contract are
+UNTOUCHED: the hugging link reaches the canvas at Tag's next recapture (or
+a deliberate `regate --write-enriched` + resolve + promote round), which
+this round did not run — the recipe's promote step has its own open row
+([§B.30](#b30-promote-floor-does-not-reproduce-the-committed-polaris-contracts)).
+
+**One instrument defect on the way.** The re-record could not un-pin a
+refusal: `drift-check.ts` pushed "FUSES AGAIN … re-record with --write" as
+a failure in BOTH modes, and `--write` refuses to write on any failure, so
+the door the message named could never open (measured: the first polaris
+re-record ran 762 s and wrote nothing). The re-record now prints the move
+and un-pins the row; the re-measure still fails on it.
+
+**Gates.** `npm run extract:computed:drift` (VERIFY) green with no refused
+row; `npm run extract:computed:drift -- --write --config
+extract/computed/configs/polaris.json` is the re-record; `npx tsx
+examples/polaris/generate.ts --check`, `figma:fresh`, `generated:fresh`,
+`evals --only polaris,promote-generalization`, tsc, lint, format, docs all
+green on the patch. Round r12 (patch over `537022b0`).

--- a/evals/results.json
+++ b/evals/results.json
@@ -1,7 +1,7 @@
 {
   "passed": 225,
   "total": 225,
-  "commit": "c27a6222c5c9ec63baa42082088ef22b58b85e6e",
+  "commit": "6ab3a5c645a12f32cea0087dd71b9885d94af6c2",
   "dirty": false,
   "recordedAt": "2026-08-23",
   "results": [

--- a/extract/computed/drift-check.ts
+++ b/extract/computed/drift-check.ts
@@ -275,7 +275,16 @@ for (const lib of selected) {
       continue;
     }
     if (REMEASURE && p?.refused) {
-      failures.push(`${key}: FUSES AGAIN — the baseline pins a refusal ("${p.refused.slice(0, 120)}") but the current engine produced a scorecard (${fmt(readRegate(freshPath).pctEqual)}); re-record with --write and say what fixed it`);
+      // A pinned refusal that fuses again is a finding for the RE-MEASURE,
+      // and exactly what the RE-RECORD exists to absorb. Until 2026-08-23
+      // (docs/23 §D.33) it was pushed as a failure in both modes, and the
+      // re-record refuses to write on any failure — so the door the message
+      // named ("re-record with --write") could never be opened: a refused
+      // row stayed pinned forever. The re-record now prints the move and
+      // un-pins the row; what fixed it belongs in the row's gapCause.
+      const moved = `${key}: FUSES AGAIN — the baseline pins a refusal ("${p.refused.slice(0, 120)}") but the current engine produced a scorecard (${fmt(readRegate(freshPath).pctEqual)})`;
+      if (WRITE) console.log(`  ↺ ${moved} — un-pinned by this re-record; say what fixed it in the row's gapCause`);
+      else failures.push(`${moved}; re-record with --write and say what fixed it`);
     }
     const fresh = readRegate(freshPath);
     const row: BaselineRow = {

--- a/extract/computed/fuse.ts
+++ b/extract/computed/fuse.ts
@@ -1320,12 +1320,31 @@ export async function boundCheck(
 }
 
 /** Channels the contract carries for a part (any combo/state) — BOUND
- *  territory; the mint pass never re-mints them. */
+ *  territory; the mint pass never re-mints them.
+ *
+ *  DEFECT FIXED (2026-08-23, docs/23 §D.33). The tokens / per-prop / literals /
+ *  states branches mapped each channel through CHANNEL_TO_COMPUTED with
+ *  `?? []`, so a channel that registry does not spell — `width`, `height`
+ *  and every other bounded channel whose computed longhand IS its own name —
+ *  was silently NOT in this set: the door said "never re-mints" and
+ *  re-minted. First measured on polaris Tag's `link` part, a display:grid
+ *  part whose G8 definite-axis pass (anatomy.ts gridDefiniteAxisLiterals,
+ *  which runs BEFORE the mint) states `literals.width = "fit-content"`; the
+ *  mint then minted `tokens.width = {imported.shared.size-59-9219}` beside it
+ *  and validateContract refused the double spelling by name (the 2026-08-23
+ *  drift re-measure's one REFUSED row). The `declared` branch below already
+ *  fell back to the channel's own name; every branch does now, so a channel
+ *  the promotion has stated — whichever field states it — is one carrier.
+ *  The same hole let a root `width`/`height` carried by a REVIEWED
+ *  literalsByProp entry (polaris avatar/progressbar/thumbnail, per size)
+ *  mint per-size leaves that the tokensByProp merge then kept out of the
+ *  contract ("conflict avoided") — orphan leaves in the minted tree. Those
+ *  are no longer minted; the contracts are byte-identical either way. */
 export function carriedChannels(part: Part | undefined): Set<string> {
   const out = new Set<string>();
   if (!part) return out;
   const addAll = (rec?: Record<string, string>) => {
-    for (const ch of Object.keys(rec ?? {})) for (const cp of CHANNEL_TO_COMPUTED[ch] ?? []) out.add(cp);
+    for (const ch of Object.keys(rec ?? {})) for (const cp of CHANNEL_TO_COMPUTED[ch] ?? [ch]) out.add(cp);
   };
   addAll(part.tokens);
   for (const e of tokensByPropEntries(part)) for (const m of Object.values(e.map)) addAll(m);
@@ -1701,7 +1720,25 @@ export function prepareMint(
       for (const channel of [...(styled.get(partName) ?? [])].sort()) {
         if (carried.has(channel)) {
           const contestingAxis = contestedByUnsetAxis(pi, channel);
-          if (contestingAxis === null) continue;
+          if (contestingAxis === null) {
+            // G8 (docs/23 §D.33): a grid part's definite axis that the
+            // promotion already states as a literal (`fit-content` when the
+            // used box equals the intrinsic track sum, else the used px) is
+            // ONE fact. The computed used box the mint would have minted is
+            // that literal's base-plane consequence, not a second fact; a
+            // fixed token beside a hugging axis would pin the canvas to the
+            // base plane's text width, and validateContract refuses the
+            // double spelling by name. The literal wins; the not-minted px
+            // is receipted here so the drop is greppable.
+            const lit = partByName.get(partName)?.literals?.[channel];
+            if (skipFolds && lit !== undefined && (channel === 'width' || channel === 'height')) {
+              const base = a.getAligned(`${space.baseComboKey}__default`)[pi]?.node.style[channel];
+              remintReceipts.push(
+                `carried-axis-not-reminted: ${partName}.${channel} — the promotion states it as literals.${channel} ${JSON.stringify(lit)} (grid-axis-definite, G8); the computed ${base ?? '<unobserved>'} is that literal's base-plane used box, not a second fact, and is NOT minted beside it (one carrier per channel — validateContract refuses two)`,
+              );
+            }
+            continue;
+          }
           if (skipFolds) {
             remintReceipts.push(
               `carried-channel-reminted: ${partName}.${channel} — observed values vary along the defaultless axis "${contestingAxis}" while the reviewed carriage has no ${contestingAxis} plane; re-minted so the set planes carry (round 5c — S2 ${contestingAxis} maps with the unset base; reviewed bindings win every collision)`,

--- a/extract/computed/out/avatar/regate.scorecard.json
+++ b/extract/computed/out/avatar/regate.scorecard.json
@@ -73,9 +73,9 @@
       "boundConfirmed": 20,
       "boundCells": 40,
       "contradictions": 20,
-      "mintedLeaves": 43,
-      "mintedLeavesUnfolded": 83,
-      "baseBindings": 19,
+      "mintedLeaves": 38,
+      "mintedLeavesUnfolded": 78,
+      "baseBindings": 18,
       "stateBindings": 0,
       "codeOnlyChannels": 0,
       "overflowBindings": 1,
@@ -211,7 +211,7 @@
     },
     "shippedMinted": {
       "path": "examples/polaris/tokens/polaris-minted.dtcg.json",
-      "leavesAdded": 1255,
+      "leavesAdded": 1260,
       "divergent": []
     },
     "rows": [

--- a/extract/computed/out/progressbar/regate.scorecard.json
+++ b/extract/computed/out/progressbar/regate.scorecard.json
@@ -111,9 +111,9 @@
       "boundConfirmed": 72,
       "boundCells": 72,
       "contradictions": 0,
-      "mintedLeaves": 15,
-      "mintedLeavesUnfolded": 15,
-      "baseBindings": 19,
+      "mintedLeaves": 12,
+      "mintedLeavesUnfolded": 12,
+      "baseBindings": 18,
       "stateBindings": 0,
       "codeOnlyChannels": 3,
       "overflowBindings": 0,
@@ -202,7 +202,7 @@
     },
     "shippedMinted": {
       "path": "examples/polaris/tokens/polaris-minted.dtcg.json",
-      "leavesAdded": 1284,
+      "leavesAdded": 1287,
       "divergent": []
     },
     "rows": [

--- a/extract/computed/out/tag/regate.scorecard.json
+++ b/extract/computed/out/tag/regate.scorecard.json
@@ -57,6 +57,11 @@
       },
       {
         "part": "label-2",
+        "channel": "font-family",
+        "value": "Inter, -apple-system, \"system-ui\", \"San Francisco\", \"Segoe UI\", Roboto, \"Helvetica Neue\", sans-serif"
+      },
+      {
+        "part": "label-2",
         "channel": "text-wrap-mode",
         "value": "nowrap"
       },
@@ -79,6 +84,11 @@
         "part": "text",
         "channel": "text-wrap-mode",
         "value": "nowrap"
+      },
+      {
+        "part": "label",
+        "channel": "font-family",
+        "value": "Inter, -apple-system, \"system-ui\", \"San Francisco\", \"Segoe UI\", Roboto, \"Helvetica Neue\", sans-serif"
       },
       {
         "part": "label",
@@ -206,9 +216,9 @@
     "combos": 32,
     "interactions": 4,
     "computed": {
-      "cellsCompared": 7401,
-      "cellsEqual": 5996,
-      "pctEqual": 81.01607890825564,
+      "cellsCompared": 7529,
+      "cellsEqual": 6140,
+      "pctEqual": 81.55133483862399,
       "rowsFullyEqual": 0,
       "rows": 128
     },
@@ -230,11 +240,11 @@
       "boundConfirmed": 132,
       "boundCells": 160,
       "contradictions": 12,
-      "mintedLeaves": 66,
-      "mintedLeavesUnfolded": 64,
-      "baseBindings": 97,
+      "mintedLeaves": 67,
+      "mintedLeavesUnfolded": 65,
+      "baseBindings": 94,
       "stateBindings": 20,
-      "codeOnlyChannels": 96,
+      "codeOnlyChannels": 95,
       "overflowBindings": 13,
       "folds": 90
     },
@@ -289,10 +299,10 @@
         "unscorable": "no-original"
       },
       {
-        "key": "large.on.off.on.enabled__hover",
+        "key": "none.on.off.off.enabled__focus-visible",
         "pctAA": null,
         "pctExact": null,
-        "channelsMismatched": 20,
+        "channelsMismatched": 19,
         "unscorable": "no-original"
       }
     ],
@@ -382,7 +392,6 @@
       "code-only: root.outline-style — declared-channel value varies across combos — declared facts carry uniform values only (v15); named residue",
       "code-only: root.text-align — declared-channel value varies across combos — declared facts carry uniform values only (v15); named residue",
       "code-only: root.text-rendering — declared-channel value varies across combos — declared facts carry uniform values only (v15); named residue",
-      "code-only: link.display — declared-channel value outside the bounded grammar — named residue (v15)",
       "code-only: link.text-decoration — value shape outside mintable kinds (color/px/number/shadow/gradient) and outside the declared-channel registry — no schema channel today",
       "code-only: text.cursor — declared-channel value varies across combos — declared facts carry uniform values only (v15); named residue",
       "code-only: text.font-feature-settings — declared-channel value varies across combos — declared facts carry uniform values only (v15); named residue",
@@ -479,7 +488,7 @@
     },
     "shippedMinted": {
       "path": "examples/polaris/tokens/polaris-minted.dtcg.json",
-      "leavesAdded": 1251,
+      "leavesAdded": 1233,
       "divergent": [
         {
           "token": "imported.tag.button.background-color.off",
@@ -522,8 +531,8 @@
     "rows": [
       {
         "key": "none.off.off.off.enabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 39,
+        "channelsCompared": 46,
+        "channelsEqual": 40,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -569,8 +578,8 @@
       },
       {
         "key": "none.off.off.off.enabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 39,
+        "channelsCompared": 46,
+        "channelsEqual": 40,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -616,8 +625,8 @@
       },
       {
         "key": "none.off.off.off.enabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 39,
+        "channelsCompared": 46,
+        "channelsEqual": 40,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -663,8 +672,8 @@
       },
       {
         "key": "none.off.off.off.enabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 39,
+        "channelsCompared": 46,
+        "channelsEqual": 40,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -710,8 +719,8 @@
       },
       {
         "key": "none.off.off.off.disabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -769,8 +778,8 @@
       },
       {
         "key": "none.off.off.off.disabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -828,8 +837,8 @@
       },
       {
         "key": "none.off.off.off.disabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -887,8 +896,8 @@
       },
       {
         "key": "none.off.off.off.disabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -946,8 +955,8 @@
       },
       {
         "key": "none.off.off.on.enabled__default",
-        "channelsCompared": 64,
-        "channelsEqual": 61,
+        "channelsCompared": 65,
+        "channelsEqual": 63,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -963,20 +972,14 @@
             "channel": "text-rendering",
             "ours": "auto",
             "theirs": "optimizelegibility"
-          },
-          {
-            "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
           }
         ],
         "note": "original screenshot unavailable — pixel not scored"
       },
       {
         "key": "none.off.off.on.enabled__hover",
-        "channelsCompared": 64,
-        "channelsEqual": 58,
+        "channelsCompared": 65,
+        "channelsEqual": 60,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1001,12 +1004,6 @@
           },
           {
             "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
-          },
-          {
-            "part": "link",
             "channel": "text-decoration",
             "ours": "none",
             "theirs": "underline"
@@ -1022,8 +1019,8 @@
       },
       {
         "key": "none.off.off.on.enabled__focus-visible",
-        "channelsCompared": 64,
-        "channelsEqual": 59,
+        "channelsCompared": 65,
+        "channelsEqual": 61,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1042,12 +1039,6 @@
           },
           {
             "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
-          },
-          {
-            "part": "link",
             "channel": "text-decoration",
             "ours": "none",
             "theirs": "underline"
@@ -1063,8 +1054,8 @@
       },
       {
         "key": "none.off.off.on.enabled__active",
-        "channelsCompared": 64,
-        "channelsEqual": 58,
+        "channelsCompared": 65,
+        "channelsEqual": 60,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1089,12 +1080,6 @@
           },
           {
             "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
-          },
-          {
-            "part": "link",
             "channel": "text-decoration",
             "ours": "none",
             "theirs": "underline"
@@ -1110,8 +1095,8 @@
       },
       {
         "key": "none.off.off.on.disabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 36,
+        "channelsCompared": 46,
+        "channelsEqual": 37,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1175,8 +1160,8 @@
       },
       {
         "key": "none.off.off.on.disabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 36,
+        "channelsCompared": 46,
+        "channelsEqual": 37,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1240,8 +1225,8 @@
       },
       {
         "key": "none.off.off.on.disabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 36,
+        "channelsCompared": 46,
+        "channelsEqual": 37,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1305,8 +1290,8 @@
       },
       {
         "key": "none.off.off.on.disabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 36,
+        "channelsCompared": 46,
+        "channelsEqual": 37,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1370,8 +1355,8 @@
       },
       {
         "key": "none.off.on.off.enabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 35,
+        "channelsCompared": 46,
+        "channelsEqual": 36,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1441,8 +1426,8 @@
       },
       {
         "key": "none.off.on.off.enabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1518,8 +1503,8 @@
       },
       {
         "key": "none.off.on.off.enabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 38,
+        "channelsCompared": 46,
+        "channelsEqual": 39,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1571,8 +1556,8 @@
       },
       {
         "key": "none.off.on.off.enabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1630,8 +1615,8 @@
       },
       {
         "key": "none.off.on.off.disabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1707,8 +1692,8 @@
       },
       {
         "key": "none.off.on.off.disabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1784,8 +1769,8 @@
       },
       {
         "key": "none.off.on.off.disabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1861,8 +1846,8 @@
       },
       {
         "key": "none.off.on.off.disabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -1938,8 +1923,8 @@
       },
       {
         "key": "none.off.on.on.enabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 35,
+        "channelsCompared": 46,
+        "channelsEqual": 36,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -2009,8 +1994,8 @@
       },
       {
         "key": "none.off.on.on.enabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -2086,8 +2071,8 @@
       },
       {
         "key": "none.off.on.on.enabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 38,
+        "channelsCompared": 46,
+        "channelsEqual": 39,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -2139,8 +2124,8 @@
       },
       {
         "key": "none.off.on.on.enabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -2198,8 +2183,8 @@
       },
       {
         "key": "none.off.on.on.disabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -2275,8 +2260,8 @@
       },
       {
         "key": "none.off.on.on.disabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -2352,8 +2337,8 @@
       },
       {
         "key": "none.off.on.on.disabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -2429,8 +2414,8 @@
       },
       {
         "key": "none.off.on.on.disabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -2506,8 +2491,8 @@
       },
       {
         "key": "none.on.off.off.enabled__default",
-        "channelsCompared": 87,
-        "channelsEqual": 76,
+        "channelsCompared": 88,
+        "channelsEqual": 77,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -2583,8 +2568,8 @@
       },
       {
         "key": "none.on.off.off.enabled__hover",
-        "channelsCompared": 87,
-        "channelsEqual": 76,
+        "channelsCompared": 88,
+        "channelsEqual": 77,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -2660,8 +2645,8 @@
       },
       {
         "key": "none.on.off.off.enabled__focus-visible",
-        "channelsCompared": 87,
-        "channelsEqual": 68,
+        "channelsCompared": 88,
+        "channelsEqual": 69,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -2785,8 +2770,8 @@
       },
       {
         "key": "none.on.off.off.enabled__active",
-        "channelsCompared": 87,
-        "channelsEqual": 76,
+        "channelsCompared": 88,
+        "channelsEqual": 77,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -2862,8 +2847,8 @@
       },
       {
         "key": "none.on.off.off.disabled__default",
-        "channelsCompared": 87,
-        "channelsEqual": 73,
+        "channelsCompared": 88,
+        "channelsEqual": 74,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -2957,8 +2942,8 @@
       },
       {
         "key": "none.on.off.off.disabled__hover",
-        "channelsCompared": 87,
-        "channelsEqual": 73,
+        "channelsCompared": 88,
+        "channelsEqual": 74,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -3052,8 +3037,8 @@
       },
       {
         "key": "none.on.off.off.disabled__focus-visible",
-        "channelsCompared": 87,
-        "channelsEqual": 72,
+        "channelsCompared": 88,
+        "channelsEqual": 73,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -3153,8 +3138,8 @@
       },
       {
         "key": "none.on.off.off.disabled__active",
-        "channelsCompared": 87,
-        "channelsEqual": 73,
+        "channelsCompared": 88,
+        "channelsEqual": 74,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -3248,8 +3233,8 @@
       },
       {
         "key": "none.on.off.on.enabled__default",
-        "channelsCompared": 106,
-        "channelsEqual": 98,
+        "channelsCompared": 107,
+        "channelsEqual": 100,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -3271,12 +3256,6 @@
             "channel": "text-rendering",
             "ours": "auto",
             "theirs": "optimizelegibility"
-          },
-          {
-            "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
           },
           {
             "part": "button-2",
@@ -3307,8 +3286,8 @@
       },
       {
         "key": "none.on.off.on.enabled__hover",
-        "channelsCompared": 106,
-        "channelsEqual": 94,
+        "channelsCompared": 107,
+        "channelsEqual": 96,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -3336,12 +3315,6 @@
             "channel": "text-rendering",
             "ours": "auto",
             "theirs": "optimizelegibility"
-          },
-          {
-            "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
           },
           {
             "part": "link",
@@ -3390,8 +3363,8 @@
       },
       {
         "key": "none.on.off.on.enabled__focus-visible",
-        "channelsCompared": 106,
-        "channelsEqual": 95,
+        "channelsCompared": 107,
+        "channelsEqual": 97,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -3413,12 +3386,6 @@
             "channel": "text-rendering",
             "ours": "auto",
             "theirs": "optimizelegibility"
-          },
-          {
-            "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
           },
           {
             "part": "link",
@@ -3467,8 +3434,8 @@
       },
       {
         "key": "none.on.off.on.enabled__active",
-        "channelsCompared": 106,
-        "channelsEqual": 94,
+        "channelsCompared": 107,
+        "channelsEqual": 96,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -3496,12 +3463,6 @@
             "channel": "text-rendering",
             "ours": "auto",
             "theirs": "optimizelegibility"
-          },
-          {
-            "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
           },
           {
             "part": "link",
@@ -3550,8 +3511,8 @@
       },
       {
         "key": "none.on.off.on.disabled__default",
-        "channelsCompared": 87,
-        "channelsEqual": 72,
+        "channelsCompared": 88,
+        "channelsEqual": 73,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -3651,8 +3612,8 @@
       },
       {
         "key": "none.on.off.on.disabled__hover",
-        "channelsCompared": 87,
-        "channelsEqual": 72,
+        "channelsCompared": 88,
+        "channelsEqual": 73,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -3752,8 +3713,8 @@
       },
       {
         "key": "none.on.off.on.disabled__focus-visible",
-        "channelsCompared": 87,
-        "channelsEqual": 71,
+        "channelsCompared": 88,
+        "channelsEqual": 72,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -3859,8 +3820,8 @@
       },
       {
         "key": "none.on.off.on.disabled__active",
-        "channelsCompared": 87,
-        "channelsEqual": 72,
+        "channelsCompared": 88,
+        "channelsEqual": 73,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -3960,8 +3921,8 @@
       },
       {
         "key": "none.on.on.off.enabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -4037,8 +3998,8 @@
       },
       {
         "key": "none.on.on.off.enabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 33,
+        "channelsCompared": 46,
+        "channelsEqual": 34,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -4120,8 +4081,8 @@
       },
       {
         "key": "none.on.on.off.enabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -4179,8 +4140,8 @@
       },
       {
         "key": "none.on.on.off.enabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 36,
+        "channelsCompared": 46,
+        "channelsEqual": 37,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -4244,8 +4205,8 @@
       },
       {
         "key": "none.on.on.off.disabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 33,
+        "channelsCompared": 46,
+        "channelsEqual": 34,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -4327,8 +4288,8 @@
       },
       {
         "key": "none.on.on.off.disabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 33,
+        "channelsCompared": 46,
+        "channelsEqual": 34,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -4410,8 +4371,8 @@
       },
       {
         "key": "none.on.on.off.disabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 33,
+        "channelsCompared": 46,
+        "channelsEqual": 34,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -4493,8 +4454,8 @@
       },
       {
         "key": "none.on.on.off.disabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 33,
+        "channelsCompared": 46,
+        "channelsEqual": 34,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -4576,8 +4537,8 @@
       },
       {
         "key": "none.on.on.on.enabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -4653,8 +4614,8 @@
       },
       {
         "key": "none.on.on.on.enabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 33,
+        "channelsCompared": 46,
+        "channelsEqual": 34,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -4736,8 +4697,8 @@
       },
       {
         "key": "none.on.on.on.enabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -4795,8 +4756,8 @@
       },
       {
         "key": "none.on.on.on.enabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 36,
+        "channelsCompared": 46,
+        "channelsEqual": 37,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -4860,8 +4821,8 @@
       },
       {
         "key": "none.on.on.on.disabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 33,
+        "channelsCompared": 46,
+        "channelsEqual": 34,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -4943,8 +4904,8 @@
       },
       {
         "key": "none.on.on.on.disabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 33,
+        "channelsCompared": 46,
+        "channelsEqual": 34,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5026,8 +4987,8 @@
       },
       {
         "key": "none.on.on.on.disabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 33,
+        "channelsCompared": 46,
+        "channelsEqual": 34,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5109,8 +5070,8 @@
       },
       {
         "key": "none.on.on.on.disabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 33,
+        "channelsCompared": 46,
+        "channelsEqual": 34,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5192,8 +5153,8 @@
       },
       {
         "key": "large.off.off.off.enabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 39,
+        "channelsCompared": 46,
+        "channelsEqual": 40,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5239,8 +5200,8 @@
       },
       {
         "key": "large.off.off.off.enabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 39,
+        "channelsCompared": 46,
+        "channelsEqual": 40,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5286,8 +5247,8 @@
       },
       {
         "key": "large.off.off.off.enabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 39,
+        "channelsCompared": 46,
+        "channelsEqual": 40,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5333,8 +5294,8 @@
       },
       {
         "key": "large.off.off.off.enabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 39,
+        "channelsCompared": 46,
+        "channelsEqual": 40,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5380,8 +5341,8 @@
       },
       {
         "key": "large.off.off.off.disabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5439,8 +5400,8 @@
       },
       {
         "key": "large.off.off.off.disabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5498,8 +5459,8 @@
       },
       {
         "key": "large.off.off.off.disabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5557,8 +5518,8 @@
       },
       {
         "key": "large.off.off.off.disabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5616,8 +5577,8 @@
       },
       {
         "key": "large.off.off.on.enabled__default",
-        "channelsCompared": 64,
-        "channelsEqual": 61,
+        "channelsCompared": 65,
+        "channelsEqual": 63,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5633,20 +5594,14 @@
             "channel": "text-rendering",
             "ours": "auto",
             "theirs": "optimizelegibility"
-          },
-          {
-            "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
           }
         ],
         "note": "original screenshot unavailable — pixel not scored"
       },
       {
         "key": "large.off.off.on.enabled__hover",
-        "channelsCompared": 64,
-        "channelsEqual": 58,
+        "channelsCompared": 65,
+        "channelsEqual": 60,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5671,12 +5626,6 @@
           },
           {
             "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
-          },
-          {
-            "part": "link",
             "channel": "text-decoration",
             "ours": "none",
             "theirs": "underline"
@@ -5692,8 +5641,8 @@
       },
       {
         "key": "large.off.off.on.enabled__focus-visible",
-        "channelsCompared": 64,
-        "channelsEqual": 59,
+        "channelsCompared": 65,
+        "channelsEqual": 61,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5712,12 +5661,6 @@
           },
           {
             "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
-          },
-          {
-            "part": "link",
             "channel": "text-decoration",
             "ours": "none",
             "theirs": "underline"
@@ -5733,8 +5676,8 @@
       },
       {
         "key": "large.off.off.on.enabled__active",
-        "channelsCompared": 64,
-        "channelsEqual": 58,
+        "channelsCompared": 65,
+        "channelsEqual": 60,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5759,12 +5702,6 @@
           },
           {
             "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
-          },
-          {
-            "part": "link",
             "channel": "text-decoration",
             "ours": "none",
             "theirs": "underline"
@@ -5780,8 +5717,8 @@
       },
       {
         "key": "large.off.off.on.disabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 36,
+        "channelsCompared": 46,
+        "channelsEqual": 37,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5845,8 +5782,8 @@
       },
       {
         "key": "large.off.off.on.disabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 36,
+        "channelsCompared": 46,
+        "channelsEqual": 37,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5910,8 +5847,8 @@
       },
       {
         "key": "large.off.off.on.disabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 36,
+        "channelsCompared": 46,
+        "channelsEqual": 37,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -5975,8 +5912,8 @@
       },
       {
         "key": "large.off.off.on.disabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 36,
+        "channelsCompared": 46,
+        "channelsEqual": 37,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -6040,8 +5977,8 @@
       },
       {
         "key": "large.off.on.off.enabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 33,
+        "channelsCompared": 46,
+        "channelsEqual": 34,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -6123,8 +6060,8 @@
       },
       {
         "key": "large.off.on.off.enabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 32,
+        "channelsCompared": 46,
+        "channelsEqual": 33,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -6212,8 +6149,8 @@
       },
       {
         "key": "large.off.on.off.enabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 36,
+        "channelsCompared": 46,
+        "channelsEqual": 37,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -6277,8 +6214,8 @@
       },
       {
         "key": "large.off.on.off.enabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 35,
+        "channelsCompared": 46,
+        "channelsEqual": 36,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -6348,8 +6285,8 @@
       },
       {
         "key": "large.off.on.off.disabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 32,
+        "channelsCompared": 46,
+        "channelsEqual": 33,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -6437,8 +6374,8 @@
       },
       {
         "key": "large.off.on.off.disabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 32,
+        "channelsCompared": 46,
+        "channelsEqual": 33,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -6526,8 +6463,8 @@
       },
       {
         "key": "large.off.on.off.disabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 32,
+        "channelsCompared": 46,
+        "channelsEqual": 33,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -6615,8 +6552,8 @@
       },
       {
         "key": "large.off.on.off.disabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 32,
+        "channelsCompared": 46,
+        "channelsEqual": 33,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -6704,8 +6641,8 @@
       },
       {
         "key": "large.off.on.on.enabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 35,
+        "channelsCompared": 46,
+        "channelsEqual": 36,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -6775,8 +6712,8 @@
       },
       {
         "key": "large.off.on.on.enabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -6852,8 +6789,8 @@
       },
       {
         "key": "large.off.on.on.enabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 38,
+        "channelsCompared": 46,
+        "channelsEqual": 39,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -6905,8 +6842,8 @@
       },
       {
         "key": "large.off.on.on.enabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -6964,8 +6901,8 @@
       },
       {
         "key": "large.off.on.on.disabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 32,
+        "channelsCompared": 46,
+        "channelsEqual": 33,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -7053,8 +6990,8 @@
       },
       {
         "key": "large.off.on.on.disabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 32,
+        "channelsCompared": 46,
+        "channelsEqual": 33,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -7142,8 +7079,8 @@
       },
       {
         "key": "large.off.on.on.disabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 32,
+        "channelsCompared": 46,
+        "channelsEqual": 33,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -7231,8 +7168,8 @@
       },
       {
         "key": "large.off.on.on.disabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 32,
+        "channelsCompared": 46,
+        "channelsEqual": 33,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -7320,8 +7257,8 @@
       },
       {
         "key": "large.on.off.off.enabled__default",
-        "channelsCompared": 86,
-        "channelsEqual": 75,
+        "channelsCompared": 87,
+        "channelsEqual": 76,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -7397,8 +7334,8 @@
       },
       {
         "key": "large.on.off.off.enabled__hover",
-        "channelsCompared": 87,
-        "channelsEqual": 67,
+        "channelsCompared": 88,
+        "channelsEqual": 68,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -7528,8 +7465,8 @@
       },
       {
         "key": "large.on.off.off.enabled__focus-visible",
-        "channelsCompared": 87,
-        "channelsEqual": 60,
+        "channelsCompared": 88,
+        "channelsEqual": 61,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -7701,8 +7638,8 @@
       },
       {
         "key": "large.on.off.off.enabled__active",
-        "channelsCompared": 87,
-        "channelsEqual": 67,
+        "channelsCompared": 88,
+        "channelsEqual": 68,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -7832,8 +7769,8 @@
       },
       {
         "key": "large.on.off.off.disabled__default",
-        "channelsCompared": 86,
-        "channelsEqual": 72,
+        "channelsCompared": 87,
+        "channelsEqual": 73,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -7927,8 +7864,8 @@
       },
       {
         "key": "large.on.off.off.disabled__hover",
-        "channelsCompared": 87,
-        "channelsEqual": 64,
+        "channelsCompared": 88,
+        "channelsEqual": 65,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -8076,8 +8013,8 @@
       },
       {
         "key": "large.on.off.off.disabled__focus-visible",
-        "channelsCompared": 86,
-        "channelsEqual": 72,
+        "channelsCompared": 87,
+        "channelsEqual": 73,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -8171,8 +8108,8 @@
       },
       {
         "key": "large.on.off.off.disabled__active",
-        "channelsCompared": 87,
-        "channelsEqual": 64,
+        "channelsCompared": 88,
+        "channelsEqual": 65,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -8320,8 +8257,8 @@
       },
       {
         "key": "large.on.off.on.enabled__default",
-        "channelsCompared": 105,
-        "channelsEqual": 97,
+        "channelsCompared": 106,
+        "channelsEqual": 99,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -8337,12 +8274,6 @@
             "channel": "text-rendering",
             "ours": "auto",
             "theirs": "optimizelegibility"
-          },
-          {
-            "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
           },
           {
             "part": "button",
@@ -8379,8 +8310,8 @@
       },
       {
         "key": "large.on.off.on.enabled__hover",
-        "channelsCompared": 106,
-        "channelsEqual": 86,
+        "channelsCompared": 107,
+        "channelsEqual": 88,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -8402,12 +8333,6 @@
             "channel": "text-rendering",
             "ours": "auto",
             "theirs": "optimizelegibility"
-          },
-          {
-            "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
           },
           {
             "part": "link",
@@ -8510,8 +8435,8 @@
       },
       {
         "key": "large.on.off.on.enabled__focus-visible",
-        "channelsCompared": 105,
-        "channelsEqual": 95,
+        "channelsCompared": 106,
+        "channelsEqual": 97,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -8527,12 +8452,6 @@
             "channel": "text-rendering",
             "ours": "auto",
             "theirs": "optimizelegibility"
-          },
-          {
-            "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
           },
           {
             "part": "link",
@@ -8581,8 +8500,8 @@
       },
       {
         "key": "large.on.off.on.enabled__active",
-        "channelsCompared": 106,
-        "channelsEqual": 86,
+        "channelsCompared": 107,
+        "channelsEqual": 88,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -8604,12 +8523,6 @@
             "channel": "text-rendering",
             "ours": "auto",
             "theirs": "optimizelegibility"
-          },
-          {
-            "part": "link",
-            "channel": "display",
-            "ours": "flex",
-            "theirs": "grid"
           },
           {
             "part": "link",
@@ -8712,8 +8625,8 @@
       },
       {
         "key": "large.on.off.on.disabled__default",
-        "channelsCompared": 86,
-        "channelsEqual": 71,
+        "channelsCompared": 87,
+        "channelsEqual": 72,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -8813,8 +8726,8 @@
       },
       {
         "key": "large.on.off.on.disabled__hover",
-        "channelsCompared": 87,
-        "channelsEqual": 63,
+        "channelsCompared": 88,
+        "channelsEqual": 64,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -8968,8 +8881,8 @@
       },
       {
         "key": "large.on.off.on.disabled__focus-visible",
-        "channelsCompared": 86,
-        "channelsEqual": 71,
+        "channelsCompared": 87,
+        "channelsEqual": 72,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -9069,8 +8982,8 @@
       },
       {
         "key": "large.on.off.on.disabled__active",
-        "channelsCompared": 87,
-        "channelsEqual": 63,
+        "channelsCompared": 88,
+        "channelsEqual": 64,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -9224,8 +9137,8 @@
       },
       {
         "key": "large.on.on.off.enabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 35,
+        "channelsCompared": 46,
+        "channelsEqual": 36,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -9295,8 +9208,8 @@
       },
       {
         "key": "large.on.on.off.enabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -9372,8 +9285,8 @@
       },
       {
         "key": "large.on.on.off.enabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 38,
+        "channelsCompared": 46,
+        "channelsEqual": 39,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -9425,8 +9338,8 @@
       },
       {
         "key": "large.on.on.off.enabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -9484,8 +9397,8 @@
       },
       {
         "key": "large.on.on.off.disabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -9561,8 +9474,8 @@
       },
       {
         "key": "large.on.on.off.disabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -9638,8 +9551,8 @@
       },
       {
         "key": "large.on.on.off.disabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -9715,8 +9628,8 @@
       },
       {
         "key": "large.on.on.off.disabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -9792,8 +9705,8 @@
       },
       {
         "key": "large.on.on.on.enabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 35,
+        "channelsCompared": 46,
+        "channelsEqual": 36,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -9863,8 +9776,8 @@
       },
       {
         "key": "large.on.on.on.enabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -9940,8 +9853,8 @@
       },
       {
         "key": "large.on.on.on.enabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 38,
+        "channelsCompared": 46,
+        "channelsEqual": 39,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -9993,8 +9906,8 @@
       },
       {
         "key": "large.on.on.on.enabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 37,
+        "channelsCompared": 46,
+        "channelsEqual": 38,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -10052,8 +9965,8 @@
       },
       {
         "key": "large.on.on.on.disabled__default",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -10129,8 +10042,8 @@
       },
       {
         "key": "large.on.on.on.disabled__hover",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -10206,8 +10119,8 @@
       },
       {
         "key": "large.on.on.on.disabled__focus-visible",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",
@@ -10283,8 +10196,8 @@
       },
       {
         "key": "large.on.on.on.disabled__active",
-        "channelsCompared": 45,
-        "channelsEqual": 34,
+        "channelsCompared": 46,
+        "channelsEqual": 35,
         "pctExact": null,
         "pctAA": null,
         "unscorable": "no-original",

--- a/extract/computed/out/thumbnail/regate.scorecard.json
+++ b/extract/computed/out/thumbnail/regate.scorecard.json
@@ -81,9 +81,9 @@
       "boundConfirmed": 20,
       "boundCells": 20,
       "contradictions": 0,
-      "mintedLeaves": 18,
-      "mintedLeavesUnfolded": 18,
-      "baseBindings": 15,
+      "mintedLeaves": 14,
+      "mintedLeavesUnfolded": 14,
+      "baseBindings": 14,
       "stateBindings": 0,
       "codeOnlyChannels": 1,
       "overflowBindings": 0,
@@ -159,7 +159,7 @@
     },
     "shippedMinted": {
       "path": "examples/polaris/tokens/polaris-minted.dtcg.json",
-      "leavesAdded": 1280,
+      "leavesAdded": 1284,
       "divergent": [
         {
           "token": "imported.thumbnail.part-0.color",

--- a/extract/computed/regate-baseline.json
+++ b/extract/computed/regate-baseline.json
@@ -707,12 +707,11 @@
     {
       "library": "polaris",
       "component": "Tag",
-      "rerunPctEqual": 81.01607890825564,
-      "cellsCompared": 7401,
+      "rerunPctEqual": 81.55133483862399,
+      "cellsCompared": 7529,
       "unresolvedTokenRefs": 0,
       "committedPctEqual": 81.01607890825564,
-      "gapCause": "REFUSED 2026-08-23 (docs/23 §B.29): the current engine (d5b5b0b1) refuses to re-fuse this component — the link part carries width as both a token binding and a literal; the numbers here are the last successful offline re-fuse (the committed regate.scorecard.json, the 2026-08-09 baseline pinned 81.016/7401). Harness number untouched.",
-      "refused": "Tag: re-fused enriched contract fails validateContract: |   - polaris.tag: part \"link\" carries channel \"width\" as BOTH a token binding ({imported.shared.size-59-9219}) and a literal (\"fit-content\") — ambiguous, refused by name: keep ONE of tokens.width / literals.width (which wins is the contract author's choice; the emitter will not pick)"
+      "gapCause": "ENGINE MOVED SINCE CAPTURE (re-recorded 2026-08-23, r12 over 537022b0; docs/23 §D.33): cells compared 7401 -> 7529, cells equal 5996 -> 6140 — 128 added cell(s), 144 more equal, so 16 previously-compared cells changed verdict to EQUAL. repaired: this row was pinned REFUSED on 2026-08-23 (§B.29) — the offline re-fuse carried link.width as BOTH the G8 literal fit-content and a minted token because fuse.ts carriedChannels mapped width through CHANNEL_TO_COMPUTED with `?? []` and so never saw the stated literal; the literal is now the one carrier (the link hugs) and the not-minted px is receipted (carried-axis-not-reminted). Harness number untouched."
     },
     {
       "library": "polaris",


### PR DESCRIPTION
Split-independent hygiene from the product/research split design (P3 §2.4 C1 + §6.6). The split itself is **not** decided; nothing here depends on it. Base `fa88dbf1`.

## C1 — the two code modules leave the capture directories

`git mv`, behaviour byte-identical; a re-export shim stays at each old path.

| was | now | importers repointed |
|---|---|---|
| `examples/polaris/scripts/lib-css.ts` | `extract/computed/lib-css.ts` | `evals/run.ts:30`, `examples/polaris/scripts/promote.ts` |
| `extract/fidelity-matrix/scripts/env.ts` | `extract/figma/visual-parity/env.ts` | `parity/snapshot-rest.ts`, `extract/figma/visual-parity/figma-api.ts` (→ `./env.js`) |

Whole-repo grep (`*.{ts,mts,mjs,js,json,md,yml}`) for the old paths: no package.json script, workflow or doc referenced either one beyond the importers above and two prose mentions (`examples/polaris/README.md`, `extract/CERTIFICATION.md`), both updated. No eval id changed; `golden.json` untouched.

## The five dead evidence citations (no number changed)

| doc | cited | now |
|---|---|---|
| `docs/20-regate-drift.md:465` | `extract/computed/out/badge/decisions.json` | the un-namespaced ledger was deleted in `d10511c4`; its rows (astryx's) survive verbatim in `extract/computed/out/astryx/badge/decisions.json`, now cited; verb past-tensed |
| `docs/23-known-limitations.md:1334` (+ bash blocks at 1294, 2551) and `docs/22-generality.md:728` | `examples/astryx/out/code-extraction.json` | never tracked — `examples/astryx/.gitignore` ignores `out/`; named as a gitignored extraction output with its regenerate command (`npm run extract:code -- examples/astryx/extract.config.json` over the PROVENANCE sandbox) |
| `docs/22-generality.md:771`, `docs/23-known-limitations.md:1398, 2558` | `examples/mui/.mui-sandbox/node_modules/@mui/material` | gitignored install sandbox (`examples/mui/.gitignore`); each block now says so and points at `examples/mui/PROVENANCE.md` |
| `docs/21-bring-your-own-design-system.md:238, 298` | `examples/carbon/.carbon-sandbox` | gitignored (`examples/carbon/.gitignore`); §2.1 now states it is never committed and that the recipe recreates it |
| `README.md:210` | `extract/computed/out/acme` | `acme` is a stand-in package name in the Journey B walkthrough; the intro now says so and that none of the `acme` paths exist in this repo |

## Why `docs:check` did not catch them

`scripts/docs-numbers-check.mjs`'s link-rot pass (§"Link rot") resolves only markdown link targets (`[text](target)`). All five citations are backtick paths or paths inside fenced `bash` blocks, which that regex never sees.

Not a one-line fix. A backtick-path pass over the same 38 gated docs (measured with a scratch script, rule: backtick text that starts with a tracked top-level dir and has no placeholder characters) flags **28** further lines today, almost all legitimate: gitignored build outputs (`figma-sync/plugin-dist/` ×9, `playground/dist/`, `site/dist/`, `evals/.ci/results.json`, `extract/computed/.drift-remeasure/`, `extract/figma/visual-parity/out/`), template placeholders (`tokens/modes/brand.acme.tokens.json`, `contracts/Badge.json`), historical script names (`figma-sync/42-table.js`, `figma-sync/28-pagination.js`), an extensionless module (`core/emit-html`), an ellipsis path, and one genuinely dead doc link (`docs/FIGMA-NODE-API-SURFACE.md` from `docs/FIGMA-CAPABILITY-MATRIX.md:24`). Fenced-block paths need a shell tokenizer, not a regex. What it takes is the design's C5 `cite:check`: a backtick/fence path pass that accepts (a) tracked files, (b) `git check-ignore` hits, (c) a `SANDBOX-PATHS`/placeholder allowlist, with the existing `docs-check:ignore` line marker for historical citations. Left for C5 rather than adding a checker that would red 28 unrelated lines.

## Gates (worktree on `fa88dbf1`, all exit 0)

tsc · lint · format:check · docs:check · ci:lanes · eval:record:check · eval:registry:check · `eval --only var-chain-resolution,polaris,parity,snapshot` (9/9 — `var-chain-resolution` pins `lib-css`; `maintain`'s `extract:figma:visual:anchors` drives the moved `env.ts` through `figma-api.ts` live) · maintain.

Full suite recorded on the clean commit: **TALLY**.
