### PR TITLE
A STRAY FILE IN examples/ CRASHED THE CORPUS GATE — named, not skipped

### DIFF
--- a/extract/figma/census/corpus.ts
+++ b/extract/figma/census/corpus.ts
@@ -133,8 +133,23 @@ export function enumerateLibraries(): {
     },
   ];
   const excluded: ExcludedEntry[] = [];
-  for (const lib of readdirSync(path.join(REPO, "examples")).sort()) {
+  for (const entry of readdirSync(path.join(REPO, "examples"), {
+    withFileTypes: true,
+  }).sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))) {
+    const lib = entry.name;
     const dir = path.join(REPO, "examples", lib);
+    // examples/ is a directory of libraries. A plain file here (.DS_Store is
+    // the one that actually happened) is not one, and readdirSync on it threw
+    // ENOTDIR two lines down — a corpus gate that crashes on desktop lint is
+    // a gate nobody can trust. Named rather than skipped: the excluded list is
+    // this file's contract that nothing leaves the denominator silently.
+    if (!entry.isDirectory()) {
+      excluded.push({
+        what: `examples/${lib}`,
+        reason: `not a directory — a stray file in examples/, not a contract library`,
+      });
+      continue;
+    }
     if (!existsSync(path.join(dir, "contracts"))) {
       const stray = readdirSync(dir).filter((f) =>
         f.endsWith(".contract.json"),


### PR DESCRIPTION
`buildManifest` called `readdirSync` on every entry of `examples/`, so a plain file there — `.DS_Store` — threw `ENOTDIR` and took `census:check` down with it. Found by the canvas-usable sweep while it was probing 162 rows.

Iterates with `withFileTypes` and records the stray in `excluded` **with its reason** rather than skipping it, matching this file's existing convention that nothing leaves the denominator silently.

**Reproduced both ways** with a real `examples/.DS_Store`: ENOTDIR before, no ENOTDIR after.

typecheck / lint / format:check / docs:check green.

**What this does not fix:** `census:check` is still RED on main for an unrelated pre-existing reason — 340 rows with no canvas PNG / no verdict.json, which arrive with the census stack (#62).
