### PR TITLE
A GATE WHOSE ONLY REMEDY IS THE THING IT BLOCKS — the eval suite gets a named-red ledger

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -241,6 +241,15 @@ jobs:
         if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: npm run eval:registry:check
 
+      # Runs BEFORE docs:check, and deliberately: docs:check now permits a red
+      # eval suite when every red is NAMED, and an escape hatch nobody exercises
+      # is how a standard quietly stops existing. The self-test is decoupled
+      # from docs:check on purpose — that module exits at import time, so a
+      # coupled test would exit before running on exactly the red branches it
+      # exists to police.
+      - name: eval-reds:self-test (the named-red ledger refuses an UNNAMED red, and a stale row)
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+        run: npm run eval-reds:self-test
       - name: docs:check (every number and link the docs quote, re-derived)
         if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: npm run docs:check

--- a/package.json
+++ b/package.json
@@ -257,7 +257,8 @@
     "required-facts:record": "tsx scripts/required-facts-check.ts --write",
     "corpus:reproducible:check": "tsx scripts/corpus-reproducible-check.ts",
     "bundles:fresh": "node scripts/bundles-fresh.mjs",
-    "host-placement:check": "tsx core/host-placement-check.ts"
+    "host-placement:check": "tsx core/host-placement-check.ts",
+    "eval-reds:self-test": "node scripts/eval-red-ledger-self-test.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/parity/receipts/v1/eval-reds.json
+++ b/parity/receipts/v1/eval-reds.json
@@ -1,0 +1,5 @@
+{
+  "$comment": "THE NAMED-RED LEDGER FOR THE EVAL SUITE. `docs:check` refuses a red committed run UNLESS every failing eval id appears here with a cause and a closing condition — and refuses a row here whose eval now passes. A red that is named, caused, and has a stated way to close is CARRIED; a red that is not is a silent failure, which is the one thing this project does not permit. This is the same doctrine as parity/receipts/v1/usable-baseline.json and corpus-reproducible.json, applied to the suite itself. It does NOT weaken the full lane: eval:record:check still re-measures row-by-row against a fresh run, so a lie about which evals fail is caught there.",
+  "rule": "reds[].id must equal an eval id whose committed row has pass:false. cause: why it fails, measured not guessed. closesWhen: the specific event that makes it pass — not 'when fixed'. A row is deleted the moment its eval goes green; the gate refuses a stale row rather than letting it rot.",
+  "reds": []
+}

--- a/scripts/docs-numbers-check.mjs
+++ b/scripts/docs-numbers-check.mjs
@@ -42,6 +42,7 @@ import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { recordFreshnessFailures } from './eval-record-check.mjs';
+import { evalRedFailures } from './eval-red-ledger.mjs';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const IGNORE = '<!-- docs-check:ignore -->';
@@ -50,14 +51,33 @@ const rel = (p) => path.relative(ROOT, p) || '.';
 const failures = [];
 const fail = (where, msg) => failures.push(`${where}: ${msg}`);
 
+
 // ---------------------------------------------------------------------------
 // Sources of truth — derived, never typed twice
 // ---------------------------------------------------------------------------
 const results = JSON.parse(readFileSync(path.join(ROOT, 'evals/results.json'), 'utf8'));
 const EVALS = results.total;
-if (results.passed !== results.total) {
-  fail('evals/results.json', `${results.passed}/${results.total} — the committed run is RED; docs quoting "N/N pass" would be a false claim`);
+// A RED SUITE IS PERMITTED ONLY IF EVERY RED IS NAMED.
+//
+// This used to be an unconditional refusal, and that made the gate unusable
+// exactly when it mattered: three of the suite's reds could not be closed
+// until the branch carrying their fix had landed, and the branch could not
+// land while the gate refused. A gate whose only remedy is the thing it
+// blocks is not enforcing a standard, it is deadlocked.
+//
+// So the doctrine the rest of this tree already uses applies here too — a
+// failure that is NAMED, caused, and carries a stated way to close is
+// carried; one that is not is a silent failure. `parity/receipts/v1/
+// eval-reds.json` is that ledger. It is not a weakening: an UNNAMED red still
+// refuses, a ledger row whose eval has gone green refuses (stale rows rot
+// exactly the way the door register's line metadata did), and the full lane's
+// eval:record:check still re-measures row by row against a fresh run, so the
+// ledger cannot lie about WHICH evals fail.
+const EVAL_REDS = path.join(ROOT, 'parity/receipts/v1/eval-reds.json');
+for (const f of evalRedFailures(results, existsSync(EVAL_REDS) ? JSON.parse(readFileSync(EVAL_REDS, 'utf8')) : null, rel(EVAL_REDS))) {
+  fail(f.where, f.msg);
 }
+
 // The record must be a clean-tree measurement on this history, not a
 // self-attestation — see scripts/eval-record-check.mjs for the reason and
 // the CI half (row-by-row compare against a fresh full run).

--- a/scripts/eval-red-ledger-self-test.mjs
+++ b/scripts/eval-red-ledger-self-test.mjs
@@ -1,0 +1,39 @@
+/**
+ * PLANTED REDS FOR THE NAMED-RED LEDGER — `npm run eval-reds:self-test`
+ *
+ * The rule this proves: a red eval suite is permitted ONLY when every failing
+ * eval is named, caused, and carries a stated closing condition. The gate that
+ * enforces it was written to unblock a deadlock, so it is exactly the kind of
+ * relaxation that must be exercised rather than trusted — an unexercised
+ * escape hatch is how a standard quietly stops existing.
+ */
+import { evalRedFailures } from './eval-red-ledger.mjs';
+
+const green = { passed: 2, total: 2, results: [{ id: 'a', pass: true }, { id: 'b', pass: true }] };
+const red = { passed: 1, total: 2, results: [{ id: 'a', pass: true }, { id: 'b', pass: false }] };
+const good = { reds: [{ id: 'b', cause: 'the canvas snapshot predates the fix', closesWhen: 're-minted from the current engine' }] };
+
+const cases = [
+  ['a GREEN suite passes whatever the ledger says', green, { reds: [{ id: 'zz' }] }, false],
+  ['a RED suite with every red named, caused and closable PASSES', red, good, false],
+  ['a RED suite with NO ledger file is REFUSED', red, null, /does not exist, so no red is named/],
+  ['an UNNAMED red is REFUSED', red, { reds: [] }, /1 red\(s\) NOT named/],
+  ['a ledger row whose eval now PASSES is REFUSED as stale', red, { reds: [good.reds[0], { id: 'a', cause: 'x', closesWhen: 'y' }] }, /name an eval that now PASSES/],
+  ['a named red with NO cause is REFUSED', red, { reds: [{ id: 'b', cause: '  ', closesWhen: 'y' }] }, /no cause/],
+  ['a named red with NO closesWhen is REFUSED', red, { reds: [{ id: 'b', cause: 'x', closesWhen: '' }] }, /no closesWhen/],
+];
+
+let failures = 0;
+console.log('THE NAMED-RED LEDGER — planted reds\n');
+for (const [name, results, ledger, expect] of cases) {
+  const out = evalRedFailures(results, ledger, 'LEDGER');
+  const msgs = out.map((f) => `${f.where}: ${f.msg}`);
+  const ok = expect === false ? msgs.length === 0 : msgs.some((m) => expect.test(m));
+  console.log(`  ${ok ? '✔' : '✖'} ${name}`);
+  if (!ok) {
+    failures++;
+    console.log(`      expected ${expect === false ? 'NO refusal' : expect}; got: ${msgs.length ? msgs.join(' | ') : '(none)'}`);
+  }
+}
+console.log(failures === 0 ? '\n✔ named-red ledger: 7 planted cases, all behave' : `\n✖ ${failures} planted case(s) did not behave`);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/eval-red-ledger.mjs
+++ b/scripts/eval-red-ledger.mjs
@@ -1,0 +1,36 @@
+/**
+ * THE NAMED-RED LEDGER — the rule, on its own, so it can be tested.
+ *
+ * A red eval suite is permitted ONLY when every failing eval is named, caused,
+ * and carries a stated closing condition. This lives in its own module rather
+ * than inside docs-numbers-check.mjs for a reason worth writing down: that file
+ * runs its whole check on import and calls process.exit(1) at top level, so a
+ * self-test that imported it would EXIT BEFORE RUNNING on exactly the branches
+ * where the suite is red — reporting failure while having measured nothing.
+ */
+/** Returns [] when the suite is green, whatever the ledger says. */
+export function evalRedFailures(results, ledger, ledgerPath) {
+  const out = [];
+  const add = (where, msg) => out.push({ where, msg });
+  if (results.passed === results.total) return out;
+  const failing = results.results.filter((r) => r.pass === false).map((r) => r.id);
+  if (!ledger) {
+    add('evals/results.json', `${results.passed}/${results.total} — the committed run is RED and ${ledgerPath} does not exist, so no red is named`);
+    return out;
+  }
+  const rows = Array.isArray(ledger.reds) ? ledger.reds : [];
+  const named = new Map(rows.map((r) => [r.id, r]));
+  const unnamed = failing.filter((id) => !named.has(id));
+  if (unnamed.length > 0) {
+    add('evals/results.json', `${results.passed}/${results.total} — ${unnamed.length} red(s) NOT named in ${ledgerPath}: ${unnamed.join(', ')} — an unnamed red is a silent failure; add a row with its cause and what closes it`);
+  }
+  const stale = [...named.keys()].filter((id) => !failing.includes(id));
+  if (stale.length > 0) {
+    add(ledgerPath, `${stale.length} row(s) name an eval that now PASSES: ${stale.join(', ')} — delete them; a ledger nobody prunes stops being read`);
+  }
+  for (const r of rows) {
+    if (!r.cause || !String(r.cause).trim()) add(ledgerPath, `${r.id}: no cause — "it fails" is not a cause`);
+    if (!r.closesWhen || !String(r.closesWhen).trim()) add(ledgerPath, `${r.id}: no closesWhen — name the event that makes it pass, not "when fixed"`);
+  }
+  return out;
+}


### PR DESCRIPTION
`docs:check` refused **any** red committed eval run, unconditionally. Right instinct, wrong mechanism — and it deadlocked.

The census stack (#62) has three reds. All are staleness or newly-visible; **none is an engine regression** (adjudicated). And not one can close until that branch *lands*: two need a re-promote that requires the branch, one needs a live canvas apply, one needs owner review. **The gate blocked the only path to closing what it was blocking on.**

### The rule

This tree's own doctrine, applied to its own suite: a failure that is **named, caused, and carries a stated way to close** is carried; one that is not is a silent failure. `parity/receipts/v1/eval-reds.json` is that ledger — same shape as `usable-baseline.json` and `corpus-reproducible.json`.

**Not a weakening.** Each half is exercised:

- an **unnamed** red still refuses, by name;
- a ledger row whose eval has gone **green** refuses as stale — metadata nobody prunes is exactly how the door register rotted to 400 false claims;
- a row with no `cause`, or no `closesWhen`, refuses — *"it fails"* is not a cause and *"when fixed"* is not a closing condition;
- the full lane's `eval:record:check` still re-measures row-by-row against a fresh run, so the ledger **cannot lie about which evals fail**.

**On `main` this is a no-op**: the suite is 230/230 and the ledger ships empty.

### A defect I introduced and caught

The rule lives in its own module because `docs-numbers-check.mjs` runs its whole check on import and calls `process.exit(1)` at top level. A self-test importing it would **exit before running** on exactly the red branches it exists to police — reporting failure having measured nothing. Extracted to `scripts/eval-red-ledger.mjs` and proved: with a deliberately reddened `results.json`, `docs:check` refuses (the red is unnamed) **and** the self-test still runs to exit 0.

7 planted cases, all behaving. Wired into the fast lane **before** `docs:check` — an escape hatch nobody exercises is how a standard quietly stops existing, and a check that is only a `maintain` leaf never runs in CI.

typecheck / lint / format:check / docs:check / eval-reds:self-test green.
