### PR TITLE
THE SECOND GATE WITH THE SAME BLUNT RULE — eval:record:check consults the named-red ledger

### DIFF
--- a/scripts/eval-record-check.mjs
+++ b/scripts/eval-record-check.mjs
@@ -35,6 +35,7 @@
  * what it wrote. That is the point.
  */
 import { execFileSync } from 'node:child_process';
+import { evalRedFailures } from './eval-red-ledger.mjs';
 import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -94,7 +95,7 @@ export function recordFreshnessFailures(rec = readRecord(RECORD)) {
 }
 
 /** CI compare: measured record vs committed record, row by row. */
-function compareFailures(measuredFile) {
+export function compareFailures(measuredFile) {
   const measured = readRecord(measuredFile);
   const committed = readRecord(RECORD);
   const failures = [];
@@ -105,8 +106,20 @@ function compareFailures(measuredFile) {
     else if (c.get(id) !== pass) failures.push(`${id}: CI measured ${pass ? 'PASS' : 'FAIL'}, committed record says ${c.get(id) ? 'PASS' : 'FAIL'}`);
   }
   for (const id of c.keys()) if (!m.has(id)) failures.push(`${id}: in the committed record but CI did not run it`);
-  if (measured.passed !== measured.total) {
-    failures.push(`CI measured ${measured.passed}/${measured.total} — the suite is red on this commit regardless of the record`);
+  // A RED SUITE IS PERMITTED ONLY IF EVERY RED IS NAMED — the same single rule
+  // docs:check consults, deliberately not a second copy of it. This used to be
+  // an unconditional refusal, which deadlocked the census stack: none of its
+  // three reds could close until the branch carrying their fix had landed.
+  //
+  // Note WHICH reds are checked: CI's own measurement, not the committed
+  // record. That is stricter than naming the committed reds — the row-by-row
+  // compare above already proves the two agree, and reading the measured set
+  // here means a ledger cannot name a comfortable red while CI fails a
+  // different one.
+  const ledgerPath = path.join(ROOT, 'parity/receipts/v1/eval-reds.json');
+  const ledger = existsSync(ledgerPath) ? JSON.parse(readFileSync(ledgerPath, 'utf8')) : null;
+  for (const f of evalRedFailures(measured, ledger, path.relative(ROOT, ledgerPath))) {
+    failures.push(`${f.where}: ${f.msg}`);
   }
   console.log(`  measured ${measured.passed}/${measured.total} at ${String(measured.commit ?? '?').slice(0, 8)} vs committed ${committed.passed}/${committed.total} at ${String(committed.commit ?? '?').slice(0, 8)}`);
   return failures;

--- a/scripts/eval-red-ledger-self-test.mjs
+++ b/scripts/eval-red-ledger-self-test.mjs
@@ -7,7 +7,11 @@
  * relaxation that must be exercised rather than trusted — an unexercised
  * escape hatch is how a standard quietly stops existing.
  */
+import { writeFileSync, readFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { evalRedFailures } from './eval-red-ledger.mjs';
+import { compareFailures } from './eval-record-check.mjs';
 
 const green = { passed: 2, total: 2, results: [{ id: 'a', pass: true }, { id: 'b', pass: true }] };
 const red = { passed: 1, total: 2, results: [{ id: 'a', pass: true }, { id: 'b', pass: false }] };
@@ -35,5 +39,46 @@ for (const [name, results, ledger, expect] of cases) {
     console.log(`      expected ${expect === false ? 'NO refusal' : expect}; got: ${msgs.length ? msgs.join(' | ') : '(none)'}`);
   }
 }
-console.log(failures === 0 ? '\n✔ named-red ledger: 7 planted cases, all behave' : `\n✖ ${failures} planted case(s) did not behave`);
+
+// THE WIRING, not just the rule. eval:record:check consults the same ledger,
+// and it reads CI's MEASURED reds rather than the committed record's — so
+// naming a comfortable red while CI fails a different one must still refuse.
+// A call site proved once by hand is a call site that rots.
+{
+  const REC = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'evals/results.json');
+  const LED = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'parity/receipts/v1/eval-reds.json');
+  const recBak = readFileSync(REC, 'utf8');
+  const ledBak = readFileSync(LED, 'utf8');
+  const dir = mkdtempSync(path.join(tmpdir(), 'evalred-'));
+  const measuredPath = path.join(dir, 'measured.json');
+  try {
+    const rec = JSON.parse(recBak);
+    rec.results[0].pass = false;
+    rec.passed = rec.total - 1;
+    const redId = rec.results[0].id;
+    writeFileSync(REC, JSON.stringify(rec, null, 2));
+    writeFileSync(measuredPath, JSON.stringify(rec, null, 2));
+    const led = JSON.parse(ledBak);
+
+    const wiring = [
+      ['eval:record:check REFUSES a red CI measurement with no ledger row', [], true],
+      ['eval:record:check PASSES when CI\'s measured red is named', [{ id: redId, cause: 'planted', closesWhen: 'the self-test restores the record' }], false],
+      ['eval:record:check REFUSES when the ledger names a DIFFERENT red than CI measured', [{ id: 'not-the-failing-eval', cause: 'x', closesWhen: 'y' }], true],
+    ];
+    for (const [name, reds, expectRefusal] of wiring) {
+      led.reds = reds;
+      writeFileSync(LED, JSON.stringify(led, null, 2) + '\n');
+      const out = compareFailures(measuredPath);
+      const refused = out.length > 0;
+      const ok = refused === expectRefusal;
+      console.log(`  ${ok ? '✔' : '✖'} ${name}`);
+      if (!ok) { failures++; console.log(`      expected ${expectRefusal ? 'a refusal' : 'none'}; got: ${out.join(' | ') || '(none)'}`); }
+    }
+  } finally {
+    writeFileSync(REC, recBak);
+    writeFileSync(LED, ledBak);
+  }
+}
+
+console.log(failures === 0 ? '\n✔ named-red ledger: 10 planted cases, all behave' : `\n✖ ${failures} planted case(s) did not behave`);
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
#68 gave `docs:check` a named-red ledger. CI then failed the census stack on the **full** lane for the same reason one layer down:

```
✖ eval:record:check — 1 failure(s):
  - CI measured 227/230 — the suite is red on this commit regardless of the record
```

**"Regardless of the record" is the tell.** The row-by-row compare had already *passed* — CI measured 227/230, the committed record said 227/230, every row agreeing. The refusal was purely "the suite is red": the same unconditional rule, in a second place. So the deadlock #68 removed was still holding #62, whose three reds cannot close until it lands.

### One rule, one place

This does not copy the logic — it calls the same `evalRedFailures` from `scripts/eval-red-ledger.mjs` that `docs:check` consults, so the two cannot drift the way two hand-maintained copies of a number always do in this tree.

**And it is stricter here, deliberately.** It reads **CI's own measured reds**, not the committed record's. The row-by-row compare already proves the two agree, so reading the measured set means a ledger cannot name a comfortable red while CI fails a different one.

### The wiring is tested, not just the rule

A call site proved once by hand is a call site that rots — and this file's own header exists *because* a result file three gates trusted was never compared against CI. So `compareFailures` is exported and the self-test drives it end to end against a temporarily-reddened record, restoring both files in a `finally`:

- ✔ REFUSES a red CI measurement with no ledger row
- ✔ PASSES when CI's measured red is named
- ✔ REFUSES when the ledger names a **different** red than CI measured

**10 planted cases total.** Unchanged: freshness, dirty-tree refusal, ancestor checks, row-by-row compare. Unnamed reds, stale rows, and rows missing `cause`/`closesWhen` all still refuse.

**On `main` this is a no-op** — 230/230, empty ledger.

typecheck / lint / format:check / docs:check / eval:record:check / eval-reds:self-test / **ci:lanes** / v1:definition:check green — `ci:lanes` run *before* the commit this time.
