### PR TITLE
THE USABLE COLUMN WAS MEASURED AND THE RECEIPT NEVER SAID SO — main was red

### DIFF
--- a/parity/receipts/v1/CANVAS-CENSUS.md
+++ b/parity/receipts/v1/CANVAS-CENSUS.md
@@ -74,60 +74,60 @@ Gate: **GREEN** at phase `code`.
 
 | library | id | archetype | axes × variants (compiled; script rows) | variants rendered | code-render | canvas | verdict | usable | walls |
 |---|---|---|---|---|---|---|---|---|---|
-| first-party | `ds.accordion-item` | accordion | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.avatar-group` | avatar | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.avatar` | avatar | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.badge` | badge / tag / chip | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.banner` | banner / alert / toast | 2 × 8; 8 | 5/5 of 8 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.bento-grid` | unmapped | 0 × 1; 6 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.blockquote` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.breadcrumb-item` | breadcrumb | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.breadcrumbs` | breadcrumb | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.button` | button | 2 × 12 + 12 state; 24 | 9/9 of 24 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.card` | card | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.chat-message-metadata` | unmapped | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.chat-message` | unmapped | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.chat-system-message` | unmapped | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.checkbox` | checkbox / radio | 2 × 6; 6 | 4/4 of 6 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.citation` | unmapped | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.code` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.divider` | unmapped | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.empty-state` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.field` | input / field | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.grid-gallery` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.heading` | unmapped | 2 × 18; 18 | 8/8 of 18 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.icon-button` | button | 2 × 12; 12 | 6/6 of 12 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.kbd` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.list-item` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.list` | unmapped | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.metadata-list-item` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.metadata-list` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.page-shell` | unmapped | 0 × 1; 5 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.pagination` | pagination | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.progress-bar` | progress / spinner | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.section` | unmapped | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.side-nav-item` | nav (top / side) | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.sidebar-layout` | unmapped | 0 × 1; 3 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.skeleton` | progress / spinner | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.slider` | slider | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.spinner` | progress / spinner | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.status-dot` | unmapped | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.switch` | toggle / switch | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.tab-list` | tabs | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.tab` | tabs | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.table-cell` | table / data-grid | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.table-header-cell` | table / data-grid | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.table-row` | table / data-grid | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.table` | table / data-grid | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.text-area` | input / field | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.text-field` | input / field | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.toast` | banner / alert / toast | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.token` | unmapped | 2 × 33; 33 | 13/13 of 33 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.toolbar` | unmapped | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.top-nav-item` | nav (top / side) | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.top-nav` | nav (top / side) | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.two-column` | unmapped | 0 × 1; 3 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| first-party | `ds.typeahead-item` | select / combobox | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
+| first-party | `ds.accordion-item` | accordion | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✓ V✓ B✘ 17/20 (85%) L✓ | — |
+| first-party | `ds.avatar-group` | avatar | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✓ 34/34 (100%) L✓ | — |
+| first-party | `ds.avatar` | avatar | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✓ V✓ B✓ 8/8 (100%) L✓ | — |
+| first-party | `ds.badge` | badge / tag / chip | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | R✓ V✘ B✓ 10/10 (100%) L✓ | — |
+| first-party | `ds.banner` | banner / alert / toast | 2 × 8; 8 | 5/5 of 8 | rendered | PENDING | PENDING | R✘ V✓ B✘ 35/38 (92%) L✘ | — |
+| first-party | `ds.bento-grid` | unmapped | 0 × 1; 6 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✘ 2/3 (67%) L✓ | — |
+| first-party | `ds.blockquote` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 6/6 (100%) L✓ | — |
+| first-party | `ds.breadcrumb-item` | breadcrumb | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✘ 5/8 (63%) L✓ | — |
+| first-party | `ds.breadcrumbs` | breadcrumb | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✘ 17/26 (65%) L✓ | — |
+| first-party | `ds.button` | button | 2 × 12 + 12 state; 24 | 9/9 of 24 | rendered | PENDING | PENDING | R✘ V✘ B✘ 15/17 (88%) L✓ | — |
+| first-party | `ds.card` | card | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✘ 33/34 (97%) L✓ | — |
+| first-party | `ds.chat-message-metadata` | unmapped | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | R✘ V✘ B✘ 6/9 (67%) L✓ | — |
+| first-party | `ds.chat-message` | unmapped | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✘ V✓ B✓ 15/15 (100%) L✓ | — |
+| first-party | `ds.chat-system-message` | unmapped | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✘ V✓ B✓ 3/3 (100%) L✓ | — |
+| first-party | `ds.checkbox` | checkbox / radio | 2 × 6; 6 | 4/4 of 6 | rendered | PENDING | PENDING | R✘ V✓ B✓ 13/13 (100%) L✓ | — |
+| first-party | `ds.citation` | unmapped | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✓ V✓ B✓ 10/10 (100%) L✓ | — |
+| first-party | `ds.code` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✓ 10/10 (100%) L✓ | — |
+| first-party | `ds.divider` | unmapped | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R· V✓ B✓ 3/3 (100%) L✓ | — |
+| first-party | `ds.empty-state` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 11/11 (100%) L✓ | — |
+| first-party | `ds.field` | input / field | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✘ 11/19 (58%) L✘ | — |
+| first-party | `ds.grid-gallery` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✘ 1/2 (50%) L✓ | — |
+| first-party | `ds.heading` | unmapped | 2 × 18; 18 | 8/8 of 18 | rendered | PENDING | PENDING | R✓ V✘ B✓ 1/1 (100%) L✓ | — |
+| first-party | `ds.icon-button` | button | 2 × 12; 12 | 6/6 of 12 | rendered | PENDING | PENDING | R✓ V✓ B✓ 7/7 (100%) L✓ | — |
+| first-party | `ds.kbd` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✓ 12/12 (100%) L✓ | — |
+| first-party | `ds.list-item` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 8/8 (100%) L✓ | — |
+| first-party | `ds.list` | unmapped | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✓ V✓ B✓ 38/38 (100%) L✓ | — |
+| first-party | `ds.metadata-list-item` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 4/4 (100%) L✓ | — |
+| first-party | `ds.metadata-list` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 16/16 (100%) L✓ | — |
+| first-party | `ds.page-shell` | unmapped | 0 × 1; 5 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✘ 2/3 (67%) L✓ | — |
+| first-party | `ds.pagination` | pagination | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✓ V✓ B✘ 46/52 (88%) L✓ | — |
+| first-party | `ds.progress-bar` | progress / spinner | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | R✘ V✓ B✘ 14/15 (93%) L✓ | — |
+| first-party | `ds.section` | unmapped | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✓ V✓ B✓ 14/14 (100%) L✓ | — |
+| first-party | `ds.side-nav-item` | nav (top / side) | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✘ V✓ B✓ 12/12 (100%) L✓ | — |
+| first-party | `ds.sidebar-layout` | unmapped | 0 × 1; 3 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✘ 1/2 (50%) L✓ | — |
+| first-party | `ds.skeleton` | progress / spinner | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✘ V✓ B✓ 7/7 (100%) L✓ | — |
+| first-party | `ds.slider` | slider | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 27/27 (100%) L✓ | — |
+| first-party | `ds.spinner` | progress / spinner | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✓ 6/6 (100%) L✓ | — |
+| first-party | `ds.status-dot` | unmapped | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | R· V✓ B✓ 7/7 (100%) L✓ | — |
+| first-party | `ds.switch` | toggle / switch | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✘ V✓ B✓ 23/23 (100%) L✓ | — |
+| first-party | `ds.tab-list` | tabs | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✓ 39/39 (100%) L✓ | — |
+| first-party | `ds.tab` | tabs | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✘ V✓ B✓ 11/11 (100%) L✓ | — |
+| first-party | `ds.table-cell` | table / data-grid | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✓ V✓ B✓ 6/6 (100%) L✓ | — |
+| first-party | `ds.table-header-cell` | table / data-grid | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✓ V✓ B✓ 6/6 (100%) L✓ | — |
+| first-party | `ds.table-row` | table / data-grid | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✓ V✓ B✓ 20/20 (100%) L✓ | — |
+| first-party | `ds.table` | table / data-grid | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✓ V✓ B✓ 90/90 (100%) L✓ | — |
+| first-party | `ds.text-area` | input / field | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✘ V✓ B✘ 23/31 (74%) L✘ | — |
+| first-party | `ds.text-field` | input / field | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✘ V✓ B✘ 23/31 (74%) L✘ | — |
+| first-party | `ds.toast` | banner / alert / toast | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✘ V✓ B✓ 11/11 (100%) L✓ | — |
+| first-party | `ds.token` | unmapped | 2 × 33; 33 | 13/13 of 33 | rendered | PENDING | PENDING | R✘ V✓ B✓ 11/11 (100%) L✓ | — |
+| first-party | `ds.toolbar` | unmapped | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✘ V✓ B✓ 17/17 (100%) L✓ | — |
+| first-party | `ds.top-nav-item` | nav (top / side) | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✘ V✓ B✓ 11/11 (100%) L✓ | — |
+| first-party | `ds.top-nav` | nav (top / side) | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✘ 12/13 (92%) L✓ | — |
+| first-party | `ds.two-column` | unmapped | 0 × 1; 3 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✘ 1/2 (50%) L✓ | — |
+| first-party | `ds.typeahead-item` | select / combobox | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 14/14 (100%) L✓ | — |
 | altitude | `altitude.avatar` | avatar | 1 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 25/25 (100%) L✓ | — |
 | altitude | `altitude.badge` | badge / tag / chip | 2 × 8; 8 | 5/5 of 8 | rendered | PENDING | PENDING | R✓ V✓ B✓ 11/11 (100%) L✓ | — |
 | altitude | `altitude.button` | button | 1 × 4 + 8 state; 12 | 6/6 of 12 | rendered | PENDING | PENDING | R✓ V✓ B✓ 13/13 (100%) L✓ | — |
@@ -136,111 +136,111 @@ Gate: **GREEN** at phase `code`.
 | altitude | `altitude.heading` | unmapped | 2 × 12; 12 | 7/7 of 12 | rendered | PENDING | PENDING | R✘ V✓ B✓ 2/2 (100%) L✓ | — |
 | altitude | `altitude.iconclose` | unmapped | 1 × 7; 7 | 7/7 of 7 | rendered | PENDING | PENDING | R✓ V✓ B✘ 3/5 (60%) L✓ | — |
 | altitude | `altitude.link` | unmapped | 1 × 3 + 6 state; 9 | 5/5 of 9 | rendered | PENDING | PENDING | R✓ V✘ B✓ 2/2 (100%) L✓ | — |
-| antd | `antd.alert` | banner / alert / toast | 2 × 8; 8 | 5/5 of 8 | rendered | PENDING | PENDING | PENDING | — |
-| antd | `antd.avatar` | avatar | 2 × 6; 6 | 4/4 of 6 | rendered | PENDING | PENDING | PENDING | — |
-| antd | `antd.badge` | badge / tag / chip | 2 × 6; 6 | 4/4 of 6 | rendered | PENDING | PENDING | PENDING | — |
-| antd | `antd.button` | button | 3 × 30; 30 | 8/8 of 30 | rendered | PENDING | PENDING | PENDING | — |
-| antd | `antd.card` | card | 2 × 4; 4 | 3/3 of 4 | rendered | PENDING | PENDING | PENDING | — |
-| antd | `antd.checkbox` | checkbox / radio | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| antd | `antd.input` | input / field | 3 × 24 + 16 state; 40 | 11/11 of 40 | rendered | PENDING | PENDING | PENDING | — |
-| antd | `antd.progress` | progress / spinner | 1 × 4; 4 | 4/4 of 4 | rendered | PENDING | PENDING | PENDING | — |
-| antd | `antd.radio` | checkbox / radio | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| antd | `antd.switch` | toggle / switch | 2 × 4 + 8 state; 12 | 7/7 of 12 | rendered | PENDING | PENDING | PENDING | — |
-| antd | `antd.tag` | badge / tag / chip | 2 × 14; 14 | 8/8 of 14 | rendered | PENDING | PENDING | PENDING | — |
-| antd | `antd.tooltip` | tooltip / popover | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| astryx | `astryx.badge` | badge / tag / chip | 1 × 14; 14 | 14/14 of 14 | rendered | PENDING | PENDING | PENDING | — |
-| astryx | `astryx.banner` | banner / alert / toast | 2 × 8; 8 | 5/5 of 8 | rendered | PENDING | PENDING | PENDING | — |
-| astryx | `astryx.button` | button | 2 × 12; 12 | 6/6 of 12 | rendered | PENDING | PENDING | PENDING | — |
-| astryx | `astryx.card` | card | 1 × 13; 13 | 13/13 of 13 | rendered | PENDING | PENDING | PENDING | — |
-| astryx | `astryx.checkbox-input` | checkbox / radio | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| astryx | `astryx.dropdown-menu-item` | menu / dropdown | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| astryx | `astryx.dropdown-menu` | menu / dropdown | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| astryx | `astryx.progress-bar` | progress / spinner | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | PENDING | — |
-| astryx | `astryx.slider` | slider | 2 × 6; 6 | 4/4 of 6 | rendered | PENDING | PENDING | PENDING | — |
-| astryx | `astryx.switch` | toggle / switch | 1 × 4; 4 | 3/3 of 4 | rendered | PENDING | PENDING | PENDING | — |
-| astryx | `astryx.text-input` | input / field | 2 × 9; 9 | 5/5 of 9 | rendered | PENDING | PENDING | PENDING | — |
-| astryx | `astryx.toast` | banner / alert / toast | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| astryx | `astryx.token` | unmapped | 2 × 33; 33 | 13/13 of 33 | rendered | PENDING | PENDING | PENDING | — |
-| carbon | `carbon.accordion` | accordion | 2 × 6 + 2 state; 8 | 4/5 of 8 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| carbon | `carbon.button` | button | 2 × 48 + 32 state; 80 | 16/17 of 80 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| carbon | `carbon.checkbox` | checkbox / radio | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| carbon | `carbon.iconbutton` | button | 2 × 16; 16 | 7/7 of 16 | rendered | PENDING | PENDING | PENDING | — |
-| carbon | `carbon.inlinenotification` | banner / alert / toast | 2 × 12; 12 | 7/7 of 12 | rendered | PENDING | PENDING | PENDING | — |
-| carbon | `carbon.modal` | modal / dialog | 1 × 4; 4 | 4/4 of 4 | rendered | PENDING | PENDING | PENDING | — |
-| carbon | `carbon.tabs` | tabs | 0 × 1 + 2 state; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| carbon | `carbon.tag` | badge / tag / chip | 2 × 36; 36 | 14/14 of 36 | rendered | PENDING | PENDING | PENDING | — |
-| carbon | `carbon.textinput` | input / field | 1 × 4 + 4 state; 8 | 4/5 of 8 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| carbon | `carbon.toggle` | toggle / switch | 1 × 2 + 2 state; 4 | 2/3 of 4 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| fluent | `fluent.avatar` | avatar | 3 × 18; 18 | 6/6 of 18 | rendered | PENDING | PENDING | PENDING | — |
-| fluent | `fluent.badge` | badge / tag / chip | 3 × 192; 192 | 16/16 of 192 | rendered | PENDING | PENDING | PENDING | — |
-| fluent | `fluent.button` | button | 3 × 45 + 20 state; 65 | 12/13 of 65 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| fluent | `fluent.card` | card | 3 × 24 + 16 state; 40 | 10/11 of 40 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| fluent | `fluent.checkbox` | checkbox / radio | 3 × 12 + 12 state; 24 | 8/9 of 24 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| fluent | `fluent.dialog` | modal / dialog | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| fluent | `fluent.input` | input / field | 2 × 18 + 24 state; 42 | 11/12 of 42 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| fluent | `fluent.spinner` | progress / spinner | 3 × 64; 64 | 12/12 of 64 | rendered | PENDING | PENDING | PENDING | — |
-| fluent | `fluent.switch` | toggle / switch | 2 × 6 + 4 state; 10 | 5/6 of 10 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| fluent | `fluent.tab-list` | tabs | 3 × 24; 24 | 7/7 of 24 | rendered | PENDING | PENDING | PENDING | — |
-| fluent | `fluent.tooltip` | tooltip / popover | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.accordion` | accordion | 2 × 4; 4 | 3/3 of 4 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.alert` | banner / alert / toast | 2 × 12; 12 | 6/6 of 12 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.autocomplete` | select / combobox | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.avatar` | avatar | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.badge` | badge / tag / chip | 2 × 14; 14 | 8/8 of 14 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.breadcrumbs` | breadcrumb | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.button` | button | 3 × 63 + 12 state; 75 | 15/15 of 75 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.card` | card | 1 × 4; 4 | 4/4 of 4 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.checkbox` | checkbox / radio | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.chip` | badge / tag / chip | 3 × 28; 28 | 9/9 of 28 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.circular-progress` | progress / spinner | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.dialog` | modal / dialog | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.divider` | unmapped | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.drawer` | modal / dialog | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.fab` | button | 2 × 9; 9 | 5/5 of 9 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.icon-button` | button | 2 × 9; 9 | 5/5 of 9 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.input-adornment` | input / field | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.linear-progress` | progress / spinner | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.link` | unmapped | 2 × 21 + 21 state; 42 | 12/12 of 42 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.menu` | menu / dropdown | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.paper` | unmapped | 2 × 8; 8 | 5/5 of 8 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.radio` | checkbox / radio | 2 × 14; 14 | 8/8 of 14 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.select` | select / combobox | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.slider` | slider | 2 × 12; 12 | 7/7 of 12 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.snackbar` | banner / alert / toast | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.switch` | toggle / switch | 3 × 28; 28 | 9/9 of 28 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.table-pagination` | pagination | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.table` | table / data-grid | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.tabs` | tabs | 2 × 6; 6 | 4/4 of 6 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.text-field` | input / field | 2 × 6; 6 | 4/4 of 6 | rendered | PENDING | PENDING | PENDING | — |
-| mui | `mui.tooltip` | tooltip / popover | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| polaris | `polaris.avatar` | avatar | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | PENDING | — |
-| polaris | `polaris.badge` | badge / tag / chip | 2 × 56; 56 | 17/17 of 56 | rendered | PENDING | PENDING | PENDING | — |
-| polaris | `polaris.banner` | banner / alert / toast | 1 × 4 + 4 state; 8 | 5/5 of 8 | rendered | PENDING | PENDING | PENDING | — |
-| polaris | `polaris.button` | button | 4 × 300 + 20 state; 320 | 17/18 of 320 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| polaris | `polaris.checkbox` | checkbox / radio | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| polaris | `polaris.progress-bar` | progress / spinner | 2 × 12; 12 | 6/6 of 12 | rendered | PENDING | PENDING | PENDING | — |
-| polaris | `polaris.radio-button` | checkbox / radio | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| polaris | `polaris.spinner` | progress / spinner | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| polaris | `polaris.tag` | badge / tag / chip | 1 × 2 + 6 state; 8 | 5/5 of 8 | rendered | PENDING | PENDING | PENDING | — |
-| polaris | `polaris.text-field` | input / field | 5 × 1344 + 56 state; 8 | 24/24 of 1400, cap 24 dropped 5, axis coverage INCOMPLETE | rendered | PENDING | PENDING | PENDING | — |
-| polaris | `polaris.text` | unmapped | 5 × 23232; 55 | 24/24 of 23232, cap 24 dropped 14, axis coverage INCOMPLETE | rendered | PENDING | PENDING | PENDING | — |
-| polaris | `polaris.thumbnail` | unmapped | 1 × 4; 4 | 4/4 of 4 | rendered | PENDING | PENDING | PENDING | — |
-| shadcn | `shadcn.alert` | banner / alert / toast | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| shadcn | `shadcn.avatar` | avatar | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | PENDING | — |
-| shadcn | `shadcn.badge` | badge / tag / chip | 1 × 6 + 12 state; 18 | 8/8 of 18 | rendered | PENDING | PENDING | PENDING | — |
-| shadcn | `shadcn.button` | button | 2 × 48 + 24 state; 72 | 16/17 of 72 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| shadcn | `shadcn.card` | card | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | PENDING | — |
-| shadcn | `shadcn.checkbox` | checkbox / radio | 1 × 3 + 6 state; 9 | 4/5 of 9 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| shadcn | `shadcn.input` | input / field | 0 × 1 + 3 state; 4 | 3/4 of 4 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| shadcn | `shadcn.select` | select / combobox | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| shadcn | `shadcn.switch` | toggle / switch | 2 × 4 + 4 state; 8 | 4/5 of 8 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| shadcn | `shadcn.tabs` | tabs | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| shadcn | `shadcn.tooltip` | tooltip / popover | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| tailwind | `flowbite.alert` | banner / alert / toast | 1 × 4; 4 | 4/4 of 4 | rendered | PENDING | PENDING | PENDING | — |
-| tailwind | `flowbite.badge` | badge / tag / chip | 2 × 12 + 12 state; 24 | 9/9 of 24 | rendered | PENDING | PENDING | PENDING | — |
-| tailwind | `flowbite.button` | button | 2 × 25 + 20 state; 45 | 12/13 of 45 | rendered, 1 refused | PENDING | PENDING | PENDING | — |
-| tailwind | `flowbite.card` | card | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| tailwind | `flowbite.helpertext` | unmapped | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | PENDING | — |
-| tailwind | `flowbite.kbd` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | PENDING | — |
-| tailwind | `flowbite.label` | unmapped | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | PENDING | — |
-| tailwind | `flowbite.toggleswitch` | toggle / switch | 2 × 6; 6 | 4/4 of 6 | rendered | PENDING | PENDING | PENDING | — |
+| antd | `antd.alert` | banner / alert / toast | 2 × 8; 8 | 5/5 of 8 | rendered | PENDING | PENDING | R✘ V✓ B✘ 20/22 (91%) L✓ | — |
+| antd | `antd.avatar` | avatar | 2 × 6; 6 | 4/4 of 6 | rendered | PENDING | PENDING | R✓ V✓ B✓ 10/10 (100%) L✓ | — |
+| antd | `antd.badge` | badge / tag / chip | 2 × 6; 6 | 4/4 of 6 | rendered | PENDING | PENDING | R✘ V✓ B✓ 26/26 (100%) L✓ | — |
+| antd | `antd.button` | button | 3 × 30; 30 | 8/8 of 30 | rendered | PENDING | PENDING | R✘ V✘ B✘ 18/22 (82%) L✓ | — |
+| antd | `antd.card` | card | 2 × 4; 4 | 3/3 of 4 | rendered | PENDING | PENDING | R✓ V✓ B✓ 23/23 (100%) L✓ | — |
+| antd | `antd.checkbox` | checkbox / radio | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✘ V✓ B✓ 21/21 (100%) L✓ | — |
+| antd | `antd.input` | input / field | 3 × 24 + 16 state; 40 | 11/11 of 40 | rendered | PENDING | PENDING | R✓ V✘ B✓ 13/13 (100%) L✓ | — |
+| antd | `antd.progress` | progress / spinner | 1 × 4; 4 | 4/4 of 4 | rendered | PENDING | PENDING | R✓ V✘ B✘ 15/16 (94%) L✓ | — |
+| antd | `antd.radio` | checkbox / radio | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✘ V✓ B✓ 21/21 (100%) L✓ | — |
+| antd | `antd.switch` | toggle / switch | 2 × 4 + 8 state; 12 | 7/7 of 12 | rendered | PENDING | PENDING | R✘ V✘ B✘ 30/31 (97%) L✓ | — |
+| antd | `antd.tag` | badge / tag / chip | 2 × 14; 14 | 8/8 of 14 | rendered | PENDING | PENDING | R✘ V✓ B✘ 14/17 (82%) L✓ | — |
+| antd | `antd.tooltip` | tooltip / popover | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 22/22 (100%) L✓ | — |
+| astryx | `astryx.badge` | badge / tag / chip | 1 × 14; 14 | 14/14 of 14 | rendered | PENDING | PENDING | R✓ V✓ B✓ 9/9 (100%) L✓ | — |
+| astryx | `astryx.banner` | banner / alert / toast | 2 × 8; 8 | 5/5 of 8 | rendered | PENDING | PENDING | R✘ V✓ B✓ 18/18 (100%) L✓ | — |
+| astryx | `astryx.button` | button | 2 × 12; 12 | 6/6 of 12 | rendered | PENDING | PENDING | R✓ V✓ B✓ 13/13 (100%) L✓ | — |
+| astryx | `astryx.card` | card | 1 × 13; 13 | 13/13 of 13 | rendered | PENDING | PENDING | R✘ V✓ B✓ 13/13 (100%) L✓ | — |
+| astryx | `astryx.checkbox-input` | checkbox / radio | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✓ V✘ B✓ 11/11 (100%) L✓ | — |
+| astryx | `astryx.dropdown-menu-item` | menu / dropdown | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✓ 9/9 (100%) L✓ | — |
+| astryx | `astryx.dropdown-menu` | menu / dropdown | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 52/52 (100%) L✓ | — |
+| astryx | `astryx.progress-bar` | progress / spinner | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | R✘ V✓ B✓ 17/17 (100%) L✓ | — |
+| astryx | `astryx.slider` | slider | 2 × 6; 6 | 4/4 of 6 | rendered | PENDING | PENDING | R✘ V✓ B✓ 41/41 (100%) L✓ | — |
+| astryx | `astryx.switch` | toggle / switch | 1 × 4; 4 | 3/3 of 4 | rendered | PENDING | PENDING | R✘ V✓ B✓ 25/25 (100%) L✓ | — |
+| astryx | `astryx.text-input` | input / field | 2 × 9; 9 | 5/5 of 9 | rendered | PENDING | PENDING | R✘ V✓ B✘ 21/22 (95%) L✓ | — |
+| astryx | `astryx.toast` | banner / alert / toast | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 25/25 (100%) L✓ | — |
+| astryx | `astryx.token` | unmapped | 2 × 33; 33 | 13/13 of 33 | rendered | PENDING | PENDING | R✓ V✓ B✓ 11/11 (100%) L✓ | — |
+| carbon | `carbon.accordion` | accordion | 2 × 6 + 2 state; 8 | 4/5 of 8 | rendered, 1 refused | PENDING | PENDING | R✓ V✓ B✘ 18/19 (95%) L✓ | — |
+| carbon | `carbon.button` | button | 2 × 48 + 32 state; 80 | 16/17 of 80 | rendered, 1 refused | PENDING | PENDING | R✘ V✘ B✓ 10/10 (100%) L✓ | — |
+| carbon | `carbon.checkbox` | checkbox / radio | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✘ V✓ B✓ 17/17 (100%) L✓ | — |
+| carbon | `carbon.iconbutton` | button | 2 × 16; 16 | 7/7 of 16 | rendered | PENDING | PENDING | R✘ V✓ B✘ 12/14 (86%) L✓ | — |
+| carbon | `carbon.inlinenotification` | banner / alert / toast | 2 × 12; 12 | 7/7 of 12 | rendered | PENDING | PENDING | R✓ V✓ B✘ 26/28 (93%) L✘ | — |
+| carbon | `carbon.modal` | modal / dialog | 1 × 4; 4 | 4/4 of 4 | rendered | PENDING | PENDING | R✓ V✓ B✘ 59/62 (95%) L✓ | — |
+| carbon | `carbon.tabs` | tabs | 0 × 1 + 2 state; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✘ V✘ B✓ 26/26 (100%) L✓ | — |
+| carbon | `carbon.tag` | badge / tag / chip | 2 × 36; 36 | 14/14 of 36 | rendered | PENDING | PENDING | R✓ V✓ B✓ 11/11 (100%) L✓ | — |
+| carbon | `carbon.textinput` | input / field | 1 × 4 + 4 state; 8 | 4/5 of 8 | rendered, 1 refused | PENDING | PENDING | R✘ V✓ B✓ 21/21 (100%) L✓ | — |
+| carbon | `carbon.toggle` | toggle / switch | 1 × 2 + 2 state; 4 | 2/3 of 4 | rendered, 1 refused | PENDING | PENDING | R✓ V✓ B✓ 18/18 (100%) L✓ | — |
+| fluent | `fluent.avatar` | avatar | 3 × 18; 18 | 6/6 of 18 | rendered | PENDING | PENDING | R✓ V✘ B✓ 16/16 (100%) L✓ | — |
+| fluent | `fluent.badge` | badge / tag / chip | 3 × 192; 192 | 16/16 of 192 | rendered | PENDING | PENDING | R✓ V✘ B✓ 10/10 (100%) L✓ | — |
+| fluent | `fluent.button` | button | 3 × 45 + 20 state; 65 | 12/13 of 65 | rendered, 1 refused | PENDING | PENDING | R✓ V✘ B✓ 13/13 (100%) L✓ | — |
+| fluent | `fluent.card` | card | 3 × 24 + 16 state; 40 | 10/11 of 40 | rendered, 1 refused | PENDING | PENDING | R✘ V✘ B✓ 22/22 (100%) L✓ | — |
+| fluent | `fluent.checkbox` | checkbox / radio | 3 × 12 + 12 state; 24 | 8/9 of 24 | rendered, 1 refused | PENDING | PENDING | R✘ V✘ B✘ 20/21 (95%) L✓ | — |
+| fluent | `fluent.dialog` | modal / dialog | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✘ V✘ B✘ 40/43 (93%) L✓ | — |
+| fluent | `fluent.input` | input / field | 2 × 18 + 24 state; 42 | 11/12 of 42 | rendered, 1 refused | PENDING | PENDING | R✓ V✘ B✓ 15/15 (100%) L✓ | — |
+| fluent | `fluent.spinner` | progress / spinner | 3 × 64; 64 | 12/12 of 64 | rendered | PENDING | PENDING | R✓ V✘ B✓ 9/9 (100%) L✓ | — |
+| fluent | `fluent.switch` | toggle / switch | 2 × 6 + 4 state; 10 | 5/6 of 10 | rendered, 1 refused | PENDING | PENDING | R✘ V✘ B✓ 23/23 (100%) L✓ | — |
+| fluent | `fluent.tab-list` | tabs | 3 × 24; 24 | 7/7 of 24 | rendered | PENDING | PENDING | R✘ V✘ B✓ 31/31 (100%) L✓ | — |
+| fluent | `fluent.tooltip` | tooltip / popover | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✘ V✓ B✓ 19/19 (100%) L✓ | — |
+| mui | `mui.accordion` | accordion | 2 × 4; 4 | 3/3 of 4 | rendered | PENDING | PENDING | R✘ V✓ B✓ 29/29 (100%) L✓ | — |
+| mui | `mui.alert` | banner / alert / toast | 2 × 12; 12 | 6/6 of 12 | rendered | PENDING | PENDING | R✘ V✓ B✓ 22/22 (100%) L✓ | — |
+| mui | `mui.autocomplete` | select / combobox | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✘ V✓ B✘ 86/92 (93%) L✓ | — |
+| mui | `mui.avatar` | avatar | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✓ V✓ B✓ 8/8 (100%) L✓ | — |
+| mui | `mui.badge` | badge / tag / chip | 2 × 14; 14 | 8/8 of 14 | rendered | PENDING | PENDING | R✘ V✓ B✓ 16/16 (100%) L✓ | — |
+| mui | `mui.breadcrumbs` | breadcrumb | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✓ 7/7 (100%) L✓ | — |
+| mui | `mui.button` | button | 3 × 63 + 12 state; 75 | 15/15 of 75 | rendered | PENDING | PENDING | R✓ V✘ B✓ 13/13 (100%) L✓ | — |
+| mui | `mui.card` | card | 1 × 4; 4 | 4/4 of 4 | rendered | PENDING | PENDING | R✓ V✘ B✓ 11/11 (100%) L✓ | — |
+| mui | `mui.checkbox` | checkbox / radio | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✓ V✓ B✓ 16/16 (100%) L✓ | — |
+| mui | `mui.chip` | badge / tag / chip | 3 × 28; 28 | 9/9 of 28 | rendered | PENDING | PENDING | R✓ V✓ B✓ 10/10 (100%) L✓ | — |
+| mui | `mui.circular-progress` | progress / spinner | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✓ V✓ B✘ 3/6 (50%) L✓ | — |
+| mui | `mui.dialog` | modal / dialog | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | R✘ V✘ B✘ 13/15 (87%) L✘ | — |
+| mui | `mui.divider` | unmapped | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R· V✓ B✓ 2/2 (100%) L✓ | — |
+| mui | `mui.drawer` | modal / dialog | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✓ V✓ B✓ 6/6 (100%) L✓ | — |
+| mui | `mui.fab` | button | 2 × 9; 9 | 5/5 of 9 | rendered | PENDING | PENDING | R✓ V✓ B✓ 8/8 (100%) L✓ | — |
+| mui | `mui.icon-button` | button | 2 × 9; 9 | 5/5 of 9 | rendered | PENDING | PENDING | R✓ V✓ B✓ 10/10 (100%) L✓ | — |
+| mui | `mui.input-adornment` | input / field | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✓ V✘ B✓ 1/1 (100%) L✓ | — |
+| mui | `mui.linear-progress` | progress / spinner | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✘ V✓ B✓ 10/10 (100%) L✓ | — |
+| mui | `mui.link` | unmapped | 2 × 21 + 21 state; 42 | 12/12 of 42 | rendered | PENDING | PENDING | R✘ V✘ B✓ 1/1 (100%) L✓ | — |
+| mui | `mui.menu` | menu / dropdown | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 28/28 (100%) L✓ | — |
+| mui | `mui.paper` | unmapped | 2 × 8; 8 | 5/5 of 8 | rendered | PENDING | PENDING | R✘ V✘ B✓ 9/9 (100%) L✓ | — |
+| mui | `mui.radio` | checkbox / radio | 2 × 14; 14 | 8/8 of 14 | rendered | PENDING | PENDING | R✓ V✘ B✓ 22/22 (100%) L✓ | — |
+| mui | `mui.select` | select / combobox | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✘ V✓ B✓ 35/35 (100%) L✓ | — |
+| mui | `mui.slider` | slider | 2 × 12; 12 | 7/7 of 12 | rendered | PENDING | PENDING | R✘ V✓ B✓ 30/30 (100%) L✓ | — |
+| mui | `mui.snackbar` | banner / alert / toast | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✓ V✘ B✓ 13/13 (100%) L✓ | — |
+| mui | `mui.switch` | toggle / switch | 3 × 28; 28 | 9/9 of 28 | rendered | PENDING | PENDING | R✘ V✘ B✓ 33/33 (100%) L✓ | — |
+| mui | `mui.table-pagination` | pagination | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✘ 67/73 (92%) L✓ | — |
+| mui | `mui.table` | table / data-grid | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✘ V✓ B✘ 170/172 (99%) L✓ | — |
+| mui | `mui.tabs` | tabs | 2 × 6; 6 | 4/4 of 6 | rendered | PENDING | PENDING | R✘ V✓ B✓ 38/38 (100%) L✓ | — |
+| mui | `mui.text-field` | input / field | 2 × 6; 6 | 4/4 of 6 | rendered | PENDING | PENDING | R✘ V✘ B✘ 35/37 (95%) L✓ | — |
+| mui | `mui.tooltip` | tooltip / popover | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✓ 15/15 (100%) L✓ | — |
+| polaris | `polaris.avatar` | avatar | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | R✘ V✓ B✓ 11/11 (100%) L✓ | — |
+| polaris | `polaris.badge` | badge / tag / chip | 2 × 56; 56 | 17/17 of 56 | rendered | PENDING | PENDING | R✓ V✓ B✓ 10/10 (100%) L✓ | — |
+| polaris | `polaris.banner` | banner / alert / toast | 1 × 4 + 4 state; 8 | 5/5 of 8 | rendered | PENDING | PENDING | R✘ V✓ B✘ 88/91 (97%) L✘ | — |
+| polaris | `polaris.button` | button | 4 × 300 + 20 state; 320 | 17/18 of 320 | rendered, 1 refused | PENDING | PENDING | R✘ V✘ B✓ 23/23 (100%) L✘ | — |
+| polaris | `polaris.checkbox` | checkbox / radio | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✓ V✓ B✓ 19/19 (100%) L✘ | — |
+| polaris | `polaris.progress-bar` | progress / spinner | 2 × 12; 12 | 6/6 of 12 | rendered | PENDING | PENDING | R✘ V✓ B✘ 9/10 (90%) L✓ | — |
+| polaris | `polaris.radio-button` | checkbox / radio | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✓ V✓ B✓ 21/21 (100%) L✘ | — |
+| polaris | `polaris.spinner` | progress / spinner | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✓ V✓ B✘ 4/6 (67%) L✓ | — |
+| polaris | `polaris.tag` | badge / tag / chip | 1 × 2 + 6 state; 8 | 5/5 of 8 | rendered | PENDING | PENDING | R✘ V✘ B✘ 31/33 (94%) L✓ | — |
+| polaris | `polaris.text-field` | input / field | 5 × 1344 + 56 state; 8 | 24/24 of 1400, cap 24 dropped 5, axis coverage INCOMPLETE | rendered | PENDING | PENDING | R✘ V✘ B✘ 31/34 (91%) L✓ | — |
+| polaris | `polaris.text` | unmapped | 5 × 23232; 55 | 24/24 of 23232, cap 24 dropped 14, axis coverage INCOMPLETE | rendered | PENDING | PENDING | R✘ V✘ B✓ 1/1 (100%) L✓ | — |
+| polaris | `polaris.thumbnail` | unmapped | 1 × 4; 4 | 4/4 of 4 | rendered | PENDING | PENDING | R✘ V✓ B✓ 15/15 (100%) L✓ | — |
+| shadcn | `shadcn.alert` | banner / alert / toast | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✘ V✓ B✓ 12/12 (100%) L✓ | — |
+| shadcn | `shadcn.avatar` | avatar | 1 × 3; 3 | 3/3 of 3 | rendered | PENDING | PENDING | R✘ V✓ B✓ 12/12 (100%) L✓ | — |
+| shadcn | `shadcn.badge` | badge / tag / chip | 1 × 6 + 12 state; 18 | 8/8 of 18 | rendered | PENDING | PENDING | R✓ V✘ B✓ 13/13 (100%) L✓ | — |
+| shadcn | `shadcn.button` | button | 2 × 48 + 24 state; 72 | 16/17 of 72 | rendered, 1 refused | PENDING | PENDING | R✓ V✘ B✓ 10/10 (100%) L✓ | — |
+| shadcn | `shadcn.card` | card | 1 × 2; 2 | 2/2 of 2 | rendered | PENDING | PENDING | R✘ V✓ B✓ 19/19 (100%) L✓ | — |
+| shadcn | `shadcn.checkbox` | checkbox / radio | 1 × 3 + 6 state; 9 | 4/5 of 9 | rendered, 1 refused | PENDING | PENDING | R· V✘ B✓ 9/9 (100%) L✓ | — |
+| shadcn | `shadcn.input` | input / field | 0 × 1 + 3 state; 4 | 3/4 of 4 | rendered, 1 refused | PENDING | PENDING | R✘ V✘ B✓ 13/13 (100%) L✓ | — |
+| shadcn | `shadcn.select` | select / combobox | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✘ 16/18 (89%) L✓ | — |
+| shadcn | `shadcn.switch` | toggle / switch | 2 × 4 + 4 state; 8 | 4/5 of 8 | rendered, 1 refused | PENDING | PENDING | R✓ V✘ B✓ 16/16 (100%) L✓ | — |
+| shadcn | `shadcn.tabs` | tabs | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 59/59 (100%) L✓ | — |
+| shadcn | `shadcn.tooltip` | tooltip / popover | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✓ V· B✓ 23/23 (100%) L✓ | — |
+| tailwind | `flowbite.alert` | banner / alert / toast | 1 × 4; 4 | 4/4 of 4 | rendered | PENDING | PENDING | R✘ V✓ B✘ 33/34 (97%) L✓ | — |
+| tailwind | `flowbite.badge` | badge / tag / chip | 2 × 12 + 12 state; 24 | 9/9 of 24 | rendered | PENDING | PENDING | R✓ V✘ B✓ 11/11 (100%) L✓ | — |
+| tailwind | `flowbite.button` | button | 2 × 25 + 20 state; 45 | 12/13 of 45 | rendered, 1 refused | PENDING | PENDING | R✓ V✘ B✓ 11/11 (100%) L✓ | — |
+| tailwind | `flowbite.card` | card | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 13/13 (100%) L✓ | — |
+| tailwind | `flowbite.helpertext` | unmapped | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | R✘ V✓ B✓ 2/2 (100%) L✓ | — |
+| tailwind | `flowbite.kbd` | unmapped | 0 × 1; 1 | 1/1 of 1 | rendered | PENDING | PENDING | R✘ V· B✓ 13/13 (100%) L✓ | — |
+| tailwind | `flowbite.label` | unmapped | 1 × 5; 5 | 5/5 of 5 | rendered | PENDING | PENDING | R✘ V✓ B✓ 2/2 (100%) L✓ | — |
+| tailwind | `flowbite.toggleswitch` | toggle / switch | 2 × 6; 6 | 4/4 of 6 | rendered | PENDING | PENDING | R✓ V✓ B✓ 25/25 (100%) L✓ | — |


### PR DESCRIPTION
#64 committed 170 canvas-usable observations. The census receipt that **prints** them was never regenerated — so `CANVAS-CENSUS.md` kept reading `PENDING` on 162 rows whose measurement was sitting in the tree beside it, and **`census:check --phase code` has been RED on `main` ever since.**

My fault twice over. I merged #64 without running `census:check` — and then I *did* see it red in the same session and attributed it to a different cause ("the canvas PNGs arrive with #62") without checking. **A red explained away with a plausible story is worse than one nobody looked at**, because it stops anyone else looking too.

Found by the layout branch (#61), which hit it while diagnosing an unrelated readiness red and did the work of proving it wasn't its own.

### The fix

Regenerated with the documented remedy, `npm run census:check -- --phase code --write-receipt`. 162 rows changed, and the diff is exactly one column:

```diff
- | first-party | ds.accordion-item | ... | PENDING | PENDING | PENDING | — |
+ | first-party | ds.accordion-item | ... | PENDING | PENDING | R✓ V✓ B✘ 17/20 (85%) L✓ | — |
```

Verified rather than assumed, because a regenerated receipt is exactly where a silent loss hides:

- **162** rows moved `PENDING` → a usability verdict — and 162 is precisely the count that was unmeasured before #64's sweep;
- **zero** removed lines carried a usability verdict, so nothing was overwritten;
- the canvas and verdict columns still read `PENDING` on all of them, which is correct at `--phase code`.

No verdict was written and none invented: `canvas 0/170`, `verdict scored 0/170`, `census/verdict.json` untouched. The 117/170 blind grades arrive with the census stack (#62).

typecheck / lint / format:check / docs:check / ci:lanes / eval:record:check / canvas:usable:check / `census:check --phase code` green.
