### PR TITLE
A RE-PROMOTION MAY ADD, MAY RESHAPE, MAY NOT QUIETLY DELETE — the curated-fact guard

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -250,6 +250,14 @@ jobs:
       - name: eval-reds:self-test (the named-red ledger refuses an UNNAMED red, and a stale row)
         if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: npm run eval-reds:self-test
+      # No gate consults the curated-fact guard yet — the re-promote wave will.
+      # Its self-test is therefore the ONLY thing keeping it honest, and the
+      # five cases that actually shipped (avatar initials, withInitials,
+      # progress 40->0, the placeholder, two radius bindings) are regression
+      # cases, not hypotheticals.
+      - name: curated-facts:self-test (a re-promotion may ADD or RESHAPE, never quietly DELETE)
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+        run: npm run curated-facts:self-test
       - name: docs:check (every number and link the docs quote, re-derived)
         if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: npm run docs:check

--- a/package.json
+++ b/package.json
@@ -258,7 +258,8 @@
     "corpus:reproducible:check": "tsx scripts/corpus-reproducible-check.ts",
     "bundles:fresh": "node scripts/bundles-fresh.mjs",
     "host-placement:check": "tsx core/host-placement-check.ts",
-    "eval-reds:self-test": "node scripts/eval-red-ledger-self-test.mjs"
+    "eval-reds:self-test": "node scripts/eval-red-ledger-self-test.mjs",
+    "curated-facts:self-test": "node scripts/curated-fact-guard-self-test.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/curated-fact-guard-self-test.mjs
+++ b/scripts/curated-fact-guard-self-test.mjs
@@ -1,0 +1,50 @@
+/**
+ * PLANTED CASES FOR THE CURATED-FACT GUARD — `npm run curated-facts:self-test`
+ *
+ * The five REAL losses of 2026-08-26 are the first five cases. If a future
+ * change to this classifier stops catching them, that change is wrong: those
+ * are not hypotheticals, they are what actually shipped and what every other
+ * gate in the tree read as an improvement.
+ */
+import { curatedFactLosses } from './curated-fact-guard.mjs';
+
+const cases = [];
+const c = (name, committed, produced, expect) => cases.push({ name, committed, produced, expect });
+
+// ---- the five that actually happened ----
+c('avatar.initials "TP" -> null is a LOSS', { initials: 'TP' }, { initials: null }, ['nulled:initials']);
+c('avatar.withInitials true -> false is a LOSS (the zero value, not an absence)', { withInitials: true }, { withInitials: false }, ['defaulted:withInitials']);
+c('progress-bar.progress 40 -> 0 is a LOSS', { progress: 40 }, { progress: 0 }, ['defaulted:progress']);
+c('text-field.placeholder "Example" -> null is a LOSS', { placeholder: 'Example' }, { placeholder: null }, ['nulled:placeholder']);
+c('thumbnail losing two radius bindings is a LOSS at each path',
+  { bindings: { borderTopLeftRadius: 'r.sm', borderTopRightRadius: 'r.sm' } },
+  { bindings: {} },
+  ['dropped:bindings.borderTopLeftRadius', 'dropped:bindings.borderTopRightRadius']);
+
+// ---- what must NOT trip it ----
+c('an unchanged contract has no losses', { a: 1, b: { c: 'x' } }, { a: 1, b: { c: 'x' } }, []);
+c('an ADDITION is not a loss', { a: 1 }, { a: 1, b: 2 }, []);
+c('a value CHANGE between two real values is not a loss', { size: 'md' }, { size: 'lg' }, []);
+c('0 -> 40 (a fact GAINED) is not a loss', { progress: 0 }, { progress: 40 }, []);
+c('false -> true is not a loss', { on: false }, { on: true }, []);
+c('key order does not matter', { a: 1, b: 2 }, { b: 2, a: 1 }, []);
+c('a non-empty array emptied is a LOSS', { parts: ['root', 'label'] }, { parts: [] }, ['emptied:parts']);
+c('an object replaced by null is a LOSS', { anatomy: { root: {} } }, { anatomy: null }, ['nulled:anatomy']);
+c('a nested scalar dropped is a LOSS at its full path', { a: { b: { c: 'keep' } } }, { a: { b: {} } }, ['dropped:a.b.c']);
+c('empty string -> empty string is not a loss', { s: '' }, { s: '' }, []);
+
+let failures = 0;
+console.log('THE CURATED-FACT GUARD — planted cases\n');
+for (const { name, committed, produced, expect } of cases) {
+  const { losses } = curatedFactLosses(committed, produced);
+  const got = losses.map((l) => `${l.kind}:${l.path}`).sort();
+  const want = [...expect].sort();
+  const ok = got.length === want.length && got.every((g, i) => g === want[i]);
+  console.log(`  ${ok ? '✔' : '✖'} ${name}`);
+  if (!ok) {
+    failures++;
+    console.log(`      expected [${want.join(', ')}]; got [${got.join(', ')}]`);
+  }
+}
+console.log(failures === 0 ? `\n✔ curated-fact guard: ${cases.length} planted cases, all behave` : `\n✖ ${failures} planted case(s) did not behave`);
+process.exit(failures === 0 ? 0 : 1);

--- a/scripts/curated-fact-guard.mjs
+++ b/scripts/curated-fact-guard.mjs
@@ -1,0 +1,122 @@
+/**
+ * THE CURATED-FACT GUARD — a re-promotion may ADD, it may RESHAPE, it may not
+ * quietly DELETE.
+ *
+ * WHY THIS EXISTS, with the exact numbers. On 2026-08-26 six polaris promote
+ * divergences "stopped happening", and that was reported up the chain — by me —
+ * as the engine getting better. It was the opposite. The divergences vanished
+ * because the CURATED FACTS had been deleted, so each contract had come to
+ * equal the promoter's bare output:
+ *
+ *     avatar.initials        "TP"      -> null
+ *     avatar.withInitials    true      -> false
+ *     progress-bar.progress    40      -> 0
+ *     text-field.placeholder "Example" -> null
+ *     thumbnail              lost two border-radius bindings
+ *
+ * An Avatar with no initials and a ProgressBar at 0% is a visible product
+ * regression that every gate in the tree called an improvement. The re-promote
+ * wave re-runs this derivation across the whole corpus, so it cannot be run as
+ * promote-and-accept.
+ *
+ * TWO THINGS THIS DELIBERATELY DOES NOT DO, both learned the same day:
+ *
+ *   · IT DOES NOT DIFF BYTES. `shadcn-minted.dtcg.json` carries the key
+ *     "color-e5e5e5" TWICE in the same object — a duplicate JSON key every
+ *     parser silently collapses. Bytes said "a leaf went missing"; parsed leaf
+ *     sets said 379 = 379. A byte-diffing guard cries wolf, and a guard that
+ *     cries wolf is one the next round learns to wave through.
+ *
+ *   · IT DOES NOT COMPARE SHAPES OR COUNTS. Every one of the five losses above
+ *     is a VALUE at a path that still exists. A guard counting parts, leaves or
+ *     keys catches none of them.
+ *
+ * So it walks PARSED values and compares FIELD BY FIELD.
+ *
+ * THE COMPARISON IT IS FOR, and the one it is NOT. Committed contract vs the
+ * output of re-promoting THAT SAME TREE. Point it across schema versions and a
+ * field the newer schema added will read as `dropped` — verified: comparing
+ * main's polaris avatar against the pre-loss `bf77a403` correctly flags
+ * `props[2].default "TP" -> undefined` and `props[6].default true -> false`,
+ * and also flags `archetype`, which is not a loss at all, only a field that
+ * did not exist yet. Same-tree is the contract; anything else needs a human.
+ *
+ * The interesting class is `defaulted`: `withInitials true -> false` and
+ * `progress 40 -> 0` are not absences. The promoter produced a well-formed
+ * contract carrying the type's zero value. That reads as data, not as damage,
+ * which is exactly why it survived review.
+ */
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+const isEmpty = (v) =>
+  v === '' ||
+  (Array.isArray(v) && v.length === 0) ||
+  (isObj(v) && Object.keys(v).length === 0);
+/** The zero value a bare re-derivation lands on when a curated fact is gone. */
+const isZero = (v) => v === false || v === 0 || v === '' || v === null;
+
+/**
+ * Classify what `produced` lost relative to `committed`.
+ * @returns {{losses: Array<{path:string,kind:string,was:unknown,now:unknown}>,
+ *            changes: Array<{path:string,was:unknown,now:unknown}>,
+ *            additions: string[]}}
+ */
+export function curatedFactLosses(committed, produced, basePath = '') {
+  const losses = [];
+  const changes = [];
+  const additions = [];
+
+  const walk = (a, b, p) => {
+    if (isObj(a)) {
+      if (!isObj(b)) {
+        losses.push({ path: p, kind: b === undefined ? 'dropped' : 'nulled', was: a, now: b });
+        return;
+      }
+      for (const k of Object.keys(a)) walk(a[k], b[k], p ? `${p}.${k}` : k);
+      for (const k of Object.keys(b)) if (!(k in a)) additions.push(p ? `${p}.${k}` : k);
+      return;
+    }
+    if (Array.isArray(a)) {
+      if (!Array.isArray(b)) {
+        losses.push({ path: p, kind: b === undefined ? 'dropped' : 'nulled', was: a, now: b });
+        return;
+      }
+      if (a.length > 0 && b.length === 0) {
+        losses.push({ path: p, kind: 'emptied', was: a, now: b });
+        return;
+      }
+      for (let i = 0; i < a.length; i++) walk(a[i], b[i], `${p}[${i}]`);
+      return;
+    }
+    // scalar
+    if (b === undefined) {
+      losses.push({ path: p, kind: 'dropped', was: a, now: b });
+      return;
+    }
+    if (a === b) return;
+    if (a !== null && b === null) {
+      losses.push({ path: p, kind: 'nulled', was: a, now: b });
+      return;
+    }
+    if (!isEmpty(a) && isEmpty(b)) {
+      losses.push({ path: p, kind: 'emptied', was: a, now: b });
+      return;
+    }
+    // The subtle one: a curated value replaced by the type's zero value.
+    if (!isZero(a) && isZero(b)) {
+      losses.push({ path: p, kind: 'defaulted', was: a, now: b });
+      return;
+    }
+    changes.push({ path: p, was: a, now: b });
+  };
+
+  walk(committed, produced, basePath);
+  return { losses, changes, additions };
+}
+
+/** One line per loss, in the shape a reviewer can act on. */
+export function formatLosses(losses) {
+  return losses.map(
+    (l) => `  ${l.kind.toUpperCase().padEnd(9)} ${l.path}: ${JSON.stringify(l.was)} -> ${JSON.stringify(l.now)}`,
+  );
+}


### PR DESCRIPTION
The re-promote wave re-runs the promoter across the whole corpus. Today gave a concrete reason not to run it as promote-and-accept.

Six polaris promote divergences "stopped happening", and **I reported that as the engine getting better. It was the opposite.** They vanished because the curated facts had been *deleted*, so each contract had come to equal the promoter's bare output:

```
avatar.initials        "TP"      -> null
avatar.withInitials    true      -> false
progress-bar.progress    40      -> 0
text-field.placeholder "Example" -> null
thumbnail              lost two border-radius bindings
```

An Avatar with no initials and a ProgressBar at 0% is a **visible product regression that every gate in this tree read as an improvement.**

### What this is

A pure classifier — committed value vs produced value, walked **field by field** — returning `losses`, `changes` and `additions` separately. A loss is `dropped`, `nulled`, `emptied`, or **`defaulted`**.

That last class is why counting doesn't work: `withInitials true → false` and `progress 40 → 0` are *not absences*. The promoter produced a well-formed contract carrying the type's zero value — which reads as data rather than damage, and is exactly why it survived review.

### Two things it deliberately does not do

- **It does not diff bytes.** `shadcn-minted.dtcg.json` carries the key `"color-e5e5e5"` **twice in the same object** — a duplicate JSON key every parser silently collapses. Bytes said "a leaf went missing"; parsed leaf sets said 379 = 379. A guard that cries wolf is one the next round learns to wave through.
- **It does not compare shapes or counts.** All five losses are *values at paths that still exist*.

### Proved on the real files

Against the actual pre-loss tree — main's polaris avatar vs `bf77a403` — it flags `props[2].default "TP" → undefined` and `props[6].default true → false`: the two that shipped.

**And its limit is documented**, because that same run also flags `archetype`, which is *not* a loss — `bf77a403` predates the field. The guard's contract is committed-vs-produced **on the same tree**; across schema versions a newly-added field reads as dropped. That's in the module header rather than left to be rediscovered.

15 planted cases; the five real ones are regression cases, not hypotheticals. **Wired into the fast lane** — no gate consults the guard yet (the wave will), so its self-test is the only thing keeping it honest.
