### PR TITLE
MY SELF-TEST WAS NOT HERMETIC — it assumed the branch it ran on was green

### DIFF
--- a/scripts/eval-red-ledger-self-test.mjs
+++ b/scripts/eval-red-ledger-self-test.mjs
@@ -52,7 +52,16 @@ for (const [name, results, ledger, expect] of cases) {
   const dir = mkdtempSync(path.join(tmpdir(), 'evalred-'));
   const measuredPath = path.join(dir, 'measured.json');
   try {
+    // HERMETIC, and it was not. This originally reddened results[0] of the
+    // repo's own record and set passed = total - 1 — which silently assumes
+    // the committed suite is GREEN. On a branch that already carries reds
+    // (the census stack carries three) the fixture then claims one failure
+    // while several rows say pass:false, the real reds come back correctly
+    // reported as unnamed, and the planted case fails for a reason that has
+    // nothing to do with what it is testing. A self-test whose verdict depends
+    // on the branch it runs in is not a self-test.
     const rec = JSON.parse(recBak);
+    for (const r of rec.results) r.pass = true;
     rec.results[0].pass = false;
     rec.passed = rec.total - 1;
     const redId = rec.results[0].id;


### PR DESCRIPTION
#69 added three wiring cases proving `eval:record:check` consults the named-red ledger. They built their fixture by reddening `results[0]` of the repo's **own** committed record and setting `passed = total - 1`.

**That silently assumes the committed suite is green.** On the census stack (#62), which carries three named reds, the fixture then claims one failure while *four* rows say `pass: false` — so the three real reds come back correctly reported as unnamed, and the planted case fails for a reason unrelated to what it tests:

```
✖ eval:record:check PASSES when CI's measured red is named
    expected none; got: 229/230 — 3 red(s) NOT named:
    astryx-reanchor-minted, minted-leaves-bind-to-something, console-loop-canvas-drift-probe
```

**The gate was right. My test was wrong, and it turned a green branch red.**

A self-test whose verdict depends on the branch it runs in is not a self-test. Same class as the waiters that matched their own command lines, and the eval that reported exit 0 while its wrapper said `EVAL_EXIT=143` — an instrument whose answer comes from its environment rather than its subject.

### Fix

Build the fixture deterministically — every row `pass: true`, then redden exactly one — so the record is 229/230 with one failure whatever the branch carries.

**Proved both ways:** with a deliberately reddened committed record carrying three extra failures, the self-test now passes (it no longer sees them); restored, it still passes. Before this change the first of those failed.

typecheck / lint / format:check / docs:check / ci:lanes / eval-reds:self-test / curated-facts:self-test / eval:record:check green.
