### PR TITLE
The full lane, run locally — the eval record points at the merged head and the mui oracle gains its 245th named receipt

### DIFF
--- a/evals/results.json
+++ b/evals/results.json
@@ -1,9 +1,9 @@
 {
   "passed": 227,
   "total": 230,
-  "commit": "181d0ab2e260130a03af38bcb6fb415ef038beda",
+  "commit": "053f2a0e50447479775dc330e123bb07da1a7714",
   "dirty": false,
-  "recordedAt": "2026-08-26",
+  "recordedAt": "2026-08-27",
   "results": [
     {
       "id": "refuse-unknown-token-reference",

--- a/examples/mui/oracle/REPORT.md
+++ b/examples/mui/oracle/REPORT.md
@@ -1,6 +1,6 @@
 # MUI oracle — offline report
 
-Run: `exact-conversion-finish-wave2` · scored 2026-08-08T07:17:19.353Z
+Run: `exact-conversion-finish-wave2` · scored 2026-08-27T00:17:49.575Z
 
 Summary: **32** MATCH · **0** PENDING · **0** FAIL / 32 facts
 

--- a/examples/mui/oracle/report.json
+++ b/examples/mui/oracle/report.json
@@ -4,7 +4,7 @@
   "version": 1,
   "runId": "exact-conversion-finish-wave2",
   "library": "mui",
-  "scoredAt": "2026-08-08T07:17:19.353Z",
+  "scoredAt": "2026-08-27T00:17:49.575Z",
   "accuracyDenominatorsUntouched": true,
   "summary": {
     "match": 32,
@@ -333,7 +333,7 @@
         "dump": false,
         "promoted": true,
         "variantAxisCount": 1,
-        "namedReceiptCount": 244
+        "namedReceiptCount": 245
       },
       "facts": [
         {


### PR DESCRIPTION
Follow-up to #62, which merged at `053f2a0e`. Three files, five lines.

- `evals/results.json` — commit pointer `181d0ab2` → `053f2a0e`, the head that actually merged. Main's pointer is a valid ancestor and `eval:record:check` passes either way; this is simply more truthful.
- `examples/mui/oracle/*` — `namedReceiptCount` 244 → 245, regenerated by the lane. The field is *written* by the report generator (`evidence.namedReceipts.length`), not asserted against a pin, so both numbers pass; 245 is what the merged engine actually produces.

**Verified on main before opening this:** `mui:oracle:corpus:check` and `eval:record:check` both pass at 244/`181d0ab2`, so this is a refinement, not a fix.

Also recorded in the commit message, and worth more than the diff — `npm run ci:lane full` **recurses**: the full lane's own step list contains `npm run ci:lane full`, so it re-enters itself. CI never hits it (the workflow runs the steps directly), but the full lane cannot be run locally unattended. Tracked separately.